### PR TITLE
Fix unitialised variable causing log spam

### DIFF
--- a/TeamProject/GameTechRenderer.h
+++ b/TeamProject/GameTechRenderer.h
@@ -68,13 +68,13 @@ namespace NCL {
 
 			GLuint lineVAO;
 			GLuint lineVertVBO;
-			size_t lineCount;
+			size_t lineCount = 0;
 
 			GLuint textVAO;
 			GLuint textVertVBO;
 			GLuint textColourVBO;
 			GLuint textTexVBO;
-			size_t textCount;
+			size_t textCount = 0;
 		};
 	}
 }


### PR DESCRIPTION
Debug drawing was trying to draw an empty buffer, which would never be resised as lineCount was > required, despite the buffer having size 0