### PR TITLE
Prebuild meshes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 .vs
 *.bak
 *.bak
+*.mshb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ if (MSVC)
 endif()
 
 add_subdirectory(NCLCoreClasses)
+add_subdirectory(MeshCompiler)
 add_subdirectory(CSC8503CoreClasses)
 add_subdirectory(OpenGLRendering)
 add_subdirectory(Network)

--- a/MeshCompiler/CMakeLists.txt
+++ b/MeshCompiler/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(SOURCES
+    main.cpp
+)
+
+add_executable(MeshCompiler ${SOURCES})
+target_link_libraries(MeshCompiler NCLCoreClasses)
+target_include_directories(MeshCompiler PRIVATE ${CMAKE_SOURCE_DIR})
+set_target_properties(MeshCompiler PROPERTIES
+    VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)

--- a/MeshCompiler/main.cpp
+++ b/MeshCompiler/main.cpp
@@ -1,0 +1,131 @@
+#include <string>
+#include <fstream>
+#include <iostream>
+
+#include <NCLCoreClasses/Mesh.h>
+#include <NCLCoreClasses/MshLoader.h>
+
+using namespace NCL::Rendering;
+
+const static constexpr uint32_t Version = 1;
+
+static void checkSize(int expected, int actual) {
+	if (expected != actual) {
+		throw std::runtime_error("Actual chunk size did not match expected");
+	}
+}
+
+template <typename T>
+static void write(std::ofstream& fs, T data) {
+	fs.write(reinterpret_cast<char*>(&data), sizeof(T));
+}
+
+template <typename T>
+static void writeOptionalChunk(std::ofstream& fs, MshLoader::GeometryChunkTypes type, const std::vector<T>& data, int expectedSize) {
+	if (data.empty()) return;
+
+	checkSize(expectedSize, data.size());
+
+	write(fs, type);
+	for (auto& v : data) {
+		write(fs, v);
+	}
+}
+
+static void writeStrings(std::ofstream& fs, const std::vector<std::string>& data) {
+	for (auto& v : data) {
+		fs.write(v.data(), v.length());
+		fs.write("\0", 1); // Null terminator
+	}
+}
+
+// Returns number of names written
+static int writeOptionalJointNames(std::ofstream& fs, const std::vector<std::string>& data) {
+	if (data.empty()) return 0;
+	
+	write(fs, MshLoader::GeometryChunkTypes::JointNames);
+	write(fs, data.size());
+
+	writeStrings(fs, data);
+
+	return data.size();
+}
+
+static void writeOptionalJointParents(std::ofstream& fs, const std::vector<int>& data, int expectedSize) {
+	if (data.empty()) return;
+	checkSize(expectedSize, data.size());
+
+	write(fs, MshLoader::GeometryChunkTypes::JointParents);
+	write(fs, data.size());
+
+	for (auto v : data) {
+		write(fs, v);
+	}
+}
+
+static void writeOptionalRigPose(std::ofstream& fs, MshLoader::GeometryChunkTypes type, const std::vector<Matrix4>& data) {
+	if (data.empty()) return;
+
+	write(fs, type);
+	write(fs, data.size());
+
+	for (auto& v : data) {
+		write(fs, v);
+	}
+}
+
+static void writeOptionalSubMeshNames(std::ofstream& fs, const std::vector<std::string>& data, int expectedCount) {
+	if (data.empty()) return;
+	checkSize(expectedCount, data.size());
+
+	writeStrings(fs, data);
+}
+
+// Binary mesh format:
+// - MSHB magic
+// - Rest of data in text mesh format, only converted to binary. Single precision floats and 32-bit integers
+
+static void convert(std::string_view source, std::string_view target) {
+	Mesh mesh;
+	bool ok = MshLoader::LoadMesh(std::string(source), mesh);
+	if (!ok) {
+		throw std::runtime_error("Failed to load mesh");
+	}
+
+	std::ofstream fs(std::string(target), std::ios::binary);
+	fs.write("MSHB", 4);
+	write(fs, Version);
+	write(fs, mesh.GetSubMeshCount());
+	write(fs, mesh.GetVertexCount());
+	write(fs, mesh.GetIndexCount());
+	write(fs, mesh.numChunks);
+
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::VPositions, mesh.GetPositionData(), mesh.GetVertexCount());
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::VColors, mesh.GetColourData(), mesh.GetVertexCount());
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::VNormals, mesh.GetNormalData(), mesh.GetVertexCount());
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::VTangents, mesh.GetTangentData(), mesh.GetVertexCount());
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::VTex0, mesh.GetTextureCoordData(), mesh.GetVertexCount());
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::Indices, mesh.GetIndexData(), mesh.GetIndexCount());
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::VWeightValues, mesh.GetSkinWeightData(), mesh.GetVertexCount());
+	int jointNameCount = writeOptionalJointNames(fs, mesh.GetJointNames());
+	writeOptionalJointParents(fs, mesh.GetJointParents(), jointNameCount);
+
+	writeOptionalRigPose(fs, MshLoader::GeometryChunkTypes::BindPose, mesh.GetBindPose());
+	writeOptionalRigPose(fs, MshLoader::GeometryChunkTypes::BindPoseInv, mesh.GetInverseBindPose());
+
+	writeOptionalChunk(fs, MshLoader::GeometryChunkTypes::SubMeshes, mesh.GetSubMeshes(), mesh.GetSubMeshCount());
+	writeOptionalSubMeshNames(fs, mesh.GetSubMeshNames(), mesh.GetSubMeshCount());
+}
+
+int main(int argc, char** argv) {
+	if (argc != 3) { // process name + source + target
+		std::cerr << "Usage: " << argv[0] << " [source] [target]" << std::endl;
+		return 1;
+	}
+
+	std::string_view source(argv[1]);
+	std::string_view target(argv[2]);
+	std::cout << "Converting " << source << " to " << target << std::endl;
+
+	convert(source, target);
+}

--- a/NCLCoreClasses/Mesh.h
+++ b/NCLCoreClasses/Mesh.h
@@ -7,6 +7,10 @@ Comments and queries to: richard-gordon.davison AT ncl.ac.uk
 https://research.ncl.ac.uk/game/
 */
 #pragma once
+
+#include <vector>
+
+#include <cassert>
 #include <cstdint>
 #include "Vector.h"
 #include "Matrix.h"
@@ -54,11 +58,12 @@ namespace NCL::Rendering {
 	struct SubMesh {
 		int start = 0;
 		int count = 0;
-		int base  = 0;
+		//int base  = 0;
 	};
 
 	class Mesh	{
 	public:		
+		Mesh();
 		virtual ~Mesh();
 
 		GeometryPrimitive::Type GetPrimitiveType() const {
@@ -129,9 +134,11 @@ namespace NCL::Rendering {
 			return &subMeshes[i];
 		}
 
+		const std::vector<SubMesh>& GetSubMeshes() const { return subMeshes; }
+
 		void AddSubMesh(int startIndex, int indexCount, int baseVertex, const std::string& newName = "") {
 			SubMesh m;
-			m.base = baseVertex;
+			//m.base = baseVertex;
 			m.count = indexCount;
 			m.start = startIndex;
 
@@ -196,7 +203,9 @@ namespace NCL::Rendering {
 
 		void SetDebugName(const std::string& debugName);
 
-		virtual void UploadToGPU(Rendering::RendererBase* renderer = nullptr) = 0;
+		virtual void UploadToGPU(Rendering::RendererBase* renderer = nullptr) {
+			assert(false && "UploadToGPU not implemented");
+		}
 
 		uint32_t GetAssetID() const {
 			return assetID;
@@ -206,9 +215,9 @@ namespace NCL::Rendering {
 			assetID = newID;
 		}
 
-	protected:
-		Mesh();
+		int numChunks;
 
+	protected:
 		virtual bool ValidateMeshData();
 
 		GeometryPrimitive::Type		primType;

--- a/NCLCoreClasses/Mesh.h
+++ b/NCLCoreClasses/Mesh.h
@@ -215,8 +215,6 @@ namespace NCL::Rendering {
 			assetID = newID;
 		}
 
-		int numChunks;
-
 	protected:
 		virtual bool ValidateMeshData();
 

--- a/NCLCoreClasses/MshLoader.cpp
+++ b/NCLCoreClasses/MshLoader.cpp
@@ -18,6 +18,7 @@ bool MshLoader::LoadMesh(const std::string& filename, Mesh& destinationMesh) {
 		return LoadBinaryMesh(binFile, destinationMesh);
 	}
 	else {
+		std::cout << filename << " is being loaded from text. Consider adding to COMPILED_MESHES" << std::endl;
 		return LoadTextMesh(filename, destinationMesh);
 	}
 }
@@ -31,11 +32,8 @@ template <typename T>
 std::vector<T> readVector(std::ifstream& fs, int size) {
 	static_assert(std::is_trivially_copyable<T>::value);
 	std::vector<T> out;
-	for (int i = 0; i < size; i++) {
-		T value;
-		read(fs, value);
-		out.push_back(value);
-	}
+	out.resize(size);
+	fs.read((char*)out.data(), size * sizeof(T));
 	return out;
 }
 
@@ -112,6 +110,9 @@ bool NCL::Rendering::MshLoader::LoadBinaryMesh(const std::string& filename, Mesh
 			auto uv = readVector<Vector2>(fs, numVertexes);
 			destinationMesh.SetVertexTextureCoords(uv);
 			break;
+		} case GeometryChunkTypes::VWeightValues: {
+			auto weights = readVector<Vector4>(fs, numVertexes);
+			destinationMesh.SetVertexSkinWeights(weights);
 		} case GeometryChunkTypes::Indices: {
 			auto indexes = readVector<unsigned int>(fs, numIndexes);
 			destinationMesh.SetVertexIndices(indexes);

--- a/NCLCoreClasses/MshLoader.cpp
+++ b/NCLCoreClasses/MshLoader.cpp
@@ -44,6 +44,7 @@ bool MshLoader::LoadMesh(const std::string& filename, Mesh& destinationMesh) {
 	file >> numVertices;
 	file >> numIndices;
 	file >> numChunks;
+	destinationMesh.numChunks = numChunks;
 
 	for (int i = 0; i < numChunks; ++i) {
 		int chunkType = (int)GeometryChunkTypes::VPositions;

--- a/NCLCoreClasses/MshLoader.cpp
+++ b/NCLCoreClasses/MshLoader.cpp
@@ -13,6 +13,128 @@ using namespace Rendering;
 using namespace Maths;
 
 bool MshLoader::LoadMesh(const std::string& filename, Mesh& destinationMesh) {
+	auto binFile(Assets::MESHDIR + filename + "b");
+	if (std::filesystem::exists(binFile)) {
+		return LoadBinaryMesh(binFile, destinationMesh);
+	}
+	else {
+		return LoadTextMesh(filename, destinationMesh);
+	}
+}
+
+template <typename T>
+void read(std::ifstream& fs, T& out) {
+	fs.read((char*)&out, sizeof(T));
+}
+
+template <typename T>
+std::vector<T> readVector(std::ifstream& fs, int size) {
+	static_assert(std::is_trivially_copyable<T>::value);
+	std::vector<T> out;
+	for (int i = 0; i < size; i++) {
+		T value;
+		read(fs, value);
+		out.push_back(value);
+	}
+	return out;
+}
+
+std::vector<std::string> readStrings(std::ifstream& fs, int size) {
+	std::vector<std::string> out;
+	for (int i = 0; i < size; i++) {
+		std::string value;
+		char ch;
+		while (true) {
+			ch = fs.get();
+			if (ch != '\0') {
+				value += ch;
+			}
+			else {
+				break;
+			}
+
+			if (value.length() > 1024) {
+				throw std::runtime_error("Unreasonably long string");
+			}
+		}
+	}
+	return out;
+}
+
+bool NCL::Rendering::MshLoader::LoadBinaryMesh(const std::string& filename, Mesh& destinationMesh)
+{
+	std::ifstream fs(filename, std::ifstream::binary);
+	if (!fs.is_open()) {
+		std::cerr << __FUNCTION__ << "Could not open mesh " << filename << std::endl;
+		return false;
+	}
+
+	char magic[4];
+	fs.read(magic, 4);
+	if (magic[0] != 'M' || magic[1] != 'S' || magic[2] != 'H' || magic[3] != 'B') {
+		std::cerr << "Invalid file type" << std::endl;
+		return false;
+	}
+
+	uint32_t version;
+	fs.read((char*)&version, sizeof(version));
+	if (version != 1) {
+		std::cout << __FUNCTION__ << " Mesh file has incompatible version!\n";
+	}
+
+	size_t numMeshes;
+	size_t numVertexes;
+	size_t numIndexes;
+	int numChunks;
+	read(fs, numMeshes);
+	read(fs, numVertexes);
+	read(fs, numIndexes);
+	read(fs, numChunks);
+
+	for (int i = 0; i < numChunks; i++) {
+		GeometryChunkTypes type;
+		read(fs, type);
+
+		switch (type) {
+		case GeometryChunkTypes::VPositions: {
+			auto vpos = readVector<Vector3>(fs, numVertexes);
+			destinationMesh.SetVertexPositions(vpos);
+			break;
+		} case GeometryChunkTypes::VNormals: {
+			auto vnorm = readVector<Vector3>(fs, numVertexes);
+			destinationMesh.SetVertexNormals(vnorm);
+			break;
+		} case GeometryChunkTypes::VTangents: {
+			auto vtan = readVector<Vector4>(fs, numVertexes);
+			destinationMesh.SetVertexTangents(vtan);
+			break;
+		} case GeometryChunkTypes::VTex0: {
+			auto uv = readVector<Vector2>(fs, numVertexes);
+			destinationMesh.SetVertexTextureCoords(uv);
+			break;
+		} case GeometryChunkTypes::Indices: {
+			auto indexes = readVector<unsigned int>(fs, numIndexes);
+			destinationMesh.SetVertexIndices(indexes);
+			break;
+		} case GeometryChunkTypes::SubMeshes: {
+			auto meshes = readVector<SubMesh>(fs, numMeshes);
+			destinationMesh.SetSubMeshes(meshes);
+			break;
+		} case GeometryChunkTypes::SubMeshNames: {
+			auto names = readStrings(fs, numMeshes);
+			destinationMesh.SetSubMeshNames(names);
+			break;
+		} default: {
+			std::cerr << __FUNCTION__ << " Unknown chunk type " << (int)type << " at offset 0x" << std::hex << fs.tellg() << std::dec << " in " << filename << std::endl;
+			return false; // Chunks do not store their length, so we can't recover from an unknown type
+		}
+		}
+	}
+
+	return true;
+}
+
+bool MshLoader::LoadTextMesh(const std::string& filename, Mesh& destinationMesh) {
 	std::ifstream file(Assets::MESHDIR + filename);
 	if (!file.is_open()) {
 		std::cerr << __FUNCTION__ << "Could not open mesh " << filename << std::endl;
@@ -44,7 +166,6 @@ bool MshLoader::LoadMesh(const std::string& filename, Mesh& destinationMesh) {
 	file >> numVertices;
 	file >> numIndices;
 	file >> numChunks;
-	destinationMesh.numChunks = numChunks;
 
 	for (int i = 0; i < numChunks; ++i) {
 		int chunkType = (int)GeometryChunkTypes::VPositions;

--- a/NCLCoreClasses/MshLoader.h
+++ b/NCLCoreClasses/MshLoader.h
@@ -45,7 +45,10 @@ namespace NCL::Rendering {
 			SubMeshNames = 1 << 15
 		};
 
+		// Load a mesh, prefering the binary version if available
 		static bool LoadMesh(const std::string& filename, Mesh& destinationMesh);
+		static bool LoadBinaryMesh(const std::string& filename, Mesh& destinationMesh);
+		static bool LoadTextMesh(const std::string& filename, Mesh& destinationMesh);
 
 	protected:
 		static void* ReadVertexData(GeometryChunkData dataType, GeometryChunkTypes chunkType, int numVertices);

--- a/NCLCoreClasses/MshLoader.h
+++ b/NCLCoreClasses/MshLoader.h
@@ -7,6 +7,8 @@ Comments and queries to: richard-gordon.davison AT ncl.ac.uk
 https://research.ncl.ac.uk/game/
 */
 #pragma once
+#include <vector>
+
 #include "Vector.h"
 #include "Matrix.h"
 
@@ -17,25 +19,6 @@ namespace NCL::Rendering {
 
 	class MshLoader	{
 
-	enum class GeometryChunkTypes {
-		VPositions = 1 << 0,
-		VNormals = 1 << 1,
-		VTangents = 1 << 2,
-		VColors = 1 << 3,
-		VTex0 = 1 << 4,
-		VTex1 = 1 << 5,
-		VWeightValues = 1 << 6,
-		VWeightIndices = 1 << 7,
-		Indices = 1 << 8,
-		JointNames = 1 << 9,
-		JointParents = 1 << 10,
-		BindPose = 1 << 11,
-		BindPoseInv = 1 << 12,
-		Material = 1 << 13,
-		SubMeshes = 1 << 14,
-		SubMeshNames = 1 << 15
-	};
-
 	enum class GeometryChunkData {
 		dFloat, //Just float data
 		dShort, //Translate from -32k to 32k to a float
@@ -43,6 +26,25 @@ namespace NCL::Rendering {
 	};
 
 	public:
+		enum class GeometryChunkTypes {
+			VPositions = 1 << 0,
+			VNormals = 1 << 1,
+			VTangents = 1 << 2,
+			VColors = 1 << 3,
+			VTex0 = 1 << 4,
+			VTex1 = 1 << 5,
+			VWeightValues = 1 << 6,
+			VWeightIndices = 1 << 7,
+			Indices = 1 << 8,
+			JointNames = 1 << 9,
+			JointParents = 1 << 10,
+			BindPose = 1 << 11,
+			BindPoseInv = 1 << 12,
+			Material = 1 << 13,
+			SubMeshes = 1 << 14,
+			SubMeshNames = 1 << 15
+		};
+
 		static bool LoadMesh(const std::string& filename, Mesh& destinationMesh);
 
 	protected:

--- a/TeamProject/CMakeLists.txt
+++ b/TeamProject/CMakeLists.txt
@@ -20,7 +20,21 @@ set(SOURCES
 	BWHelperFunctions.cpp
 )
 
+set(COMPILED_MESHES
+    Plane.msh
+    cube.msh
+    sphere.msh
+    ORIGAMI_Chat.msh
+    Kitten.msh
+    Keeper.msh
+    19463_Kitten_Head_v1.msh
+    /Max/Rig_Maximilian.msh
+    /MaleGuard/Male_Guard.msh
+    /FemaleGuard/Female_Guard.msh
+)
+
 add_executable(${PROJECT_NAME} ${SOURCES})
+add_dependencies(${PROJECT_NAME} MeshCompiler)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VS_GLOBAL_KEYWORD "Win32Proj"
@@ -92,3 +106,17 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VS_DEBUGGER_WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
+
+foreach(file ${COMPILED_MESHES})
+    set(out "${CMAKE_SOURCE_DIR}/Assets/Meshes/${file}b")
+    add_custom_command(
+        OUTPUT ${out}
+        COMMAND MeshCompiler ${file} ${out}
+        DEPENDS "${CMAKE_SOURCE_DIR}/Assets/Meshes/${file}" MeshCompiler
+        COMMENT "Compiling mesh ${file}"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    list(APPEND PROCESSED_MESHES ${out})
+endforeach()
+add_custom_target(ProcessMeshes ALL DEPENDS ${PROCESSED_MESHES})
+add_dependencies(${PROJECT_NAME} ProcessMeshes)

--- a/TeamProject/CMakeLists.txt
+++ b/TeamProject/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
 )
 
 set(COMPILED_MESHES
+    capsule.msh
     Plane.msh
     cube.msh
     sphere.msh


### PR DESCRIPTION
Add a MeshCompiler build target, and run meshes through this during build of the game. Gives a significant speed up according to profiling (80% of startup time loading meshes -> 5%)

Binary meshes are automatically loaded when available with a suggestion to convert any text meshes

The .mshb format is essentially a binary dump of a text mesh, and is not tested for robustness