### PR TITLE
Fixed Wall Colliders

### DIFF
--- a/CSC8503CoreClasses/PhysicsObject.cpp
+++ b/CSC8503CoreClasses/PhysicsObject.cpp
@@ -66,6 +66,42 @@ void PhysicsObject::InitBulletPhysics(btDynamicsWorld* world, btCollisionShape* 
 	}
 }
 
+void PhysicsObject::InitBulletPhysics(btDynamicsWorld* world, btCompoundShape* compoundShape, float mass, bool collide)
+{
+	btTransform startTransform;
+	startTransform.setIdentity();
+
+	Vector3 initialPosition = parent->getInitialPosition();
+	Quaternion initialOrientation = parent->getInitialRotation();
+
+	// Setting the starting position of the object using the NCL framework's transform
+	startTransform.setOrigin(btVector3(initialPosition.x, initialPosition.y, initialPosition.z));
+	startTransform.setRotation(btQuaternion(initialOrientation.x, initialOrientation.y, initialOrientation.z, initialOrientation.w));
+
+	// MotionState has been used to retrieve and apply Bullet's physics transformations to the NCL object
+	motionState = new btDefaultMotionState(startTransform);
+
+	btVector3 localInertia(0, 0, 0);
+	if (mass > 0.0f && compoundShape) {
+		compoundShape->calculateLocalInertia(mass, localInertia);
+	}
+
+	btRigidBody::btRigidBodyConstructionInfo rbInfo(mass, motionState, compoundShape, localInertia);
+	rigidBody = new btRigidBody(rbInfo);
+
+	// Setting the object's properties
+	rigidBody->setMassProps(mass, localInertia);
+	rigidBody->setUserPointer(parent);
+	rigidBody->setActivationState(DISABLE_DEACTIVATION);
+
+	if (collide) {
+		world->addRigidBody(rigidBody);
+#ifndef NDEBUG
+		hasBullet = true;
+#endif
+	}
+}
+
 
 
 void NCL::CSC8503::PhysicsObject::removeFromBullet(btDynamicsWorld* world)

--- a/CSC8503CoreClasses/PhysicsObject.h
+++ b/CSC8503CoreClasses/PhysicsObject.h
@@ -20,6 +20,7 @@ namespace NCL {
 
 			// Add Bullet-specific methods
 			void InitBulletPhysics(btDynamicsWorld* world, btCollisionShape* shape, float mass, bool collide=true);
+			void InitBulletPhysics(btDynamicsWorld* world, btCompoundShape* compoundShape, float mass, bool collide = true);
 			void removeFromBullet(btDynamicsWorld* world);
 			btRigidBody* GetRigidBody() { return rigidBody; }
 

--- a/TeamProject/LevelImporter.cpp
+++ b/TeamProject/LevelImporter.cpp
@@ -74,11 +74,13 @@ void LevelImporter::LoadLevel(int level) {
 void LevelImporter::AddObjectToWorld(ObjectData* data) {
     GameObject* cube = new GameObject();
 
-    // Setting the transform properties for the cube
-
-
+    // Initializing variables for meshes and textures
     Mesh* selectedMesh = nullptr;
     Texture* selectedTex = basicTex;
+    bool isFloor = false;
+
+	// This mesh names have been used to identify the objects in the level
+	// and set the offset for the wall only as the collider is not aligned with the mesh
     if (data->meshName == "corridor_walls_and_floor:corridor_Wall_Straight_Mid_end_L") {
         selectedMesh = wallSection;
         selectedTex = wallTex;
@@ -86,22 +88,25 @@ void LevelImporter::AddObjectToWorld(ObjectData* data) {
     else if (data->meshName == "corridor_walls_and_floor:Corridor_Floor_Basic") {
         selectedMesh = floorSection;
         selectedTex = basicTex;
+		isFloor = true;
     }
     else {
         std::cerr << "NO MESH FOUND FOR LEVEL OBJECT" << std::endl;
         return;
     }
 
+	// If not a floor, apply an offset to move the floor up/down
+    Vector3 position = data->position * scale;
+    if (!isFloor) {
+        position.y -= 8.0f;
+    }
+	cube->setInitialPosition(position);
+
     btVector3 eulerRotation = btVector3(data->rotation.getX(), data->rotation.getY(), data->rotation.getZ());
     if (selectedMesh == wallSection) {
         eulerRotation.setX(eulerRotation.getX() - 90);
-        cube->setInitialPosition(data->position* scale);
     }
-    else {
-        btVector3 pos = data->position;
-        pos.setY(pos.getY() + (0.75));
-        cube->setInitialPosition(pos* scale);
-    }
+
     float pitchRadians = Maths::DegreesToRadians(eulerRotation.x());
     float yawRadians = Maths::DegreesToRadians(eulerRotation.y());
     float rollRadians = Maths::DegreesToRadians(eulerRotation.z());
@@ -110,25 +115,39 @@ void LevelImporter::AddObjectToWorld(ObjectData* data) {
 
     cube->setInitialRotation(Quaternion(rotationQuat.getX(), rotationQuat.getY(), rotationQuat.getZ(), rotationQuat.getW()));
 
-
-    cube->setRenderScale(data->scale* scale);
-
+	// Adjusting the render scale to match the collider scale
+    Vector3 adjustedScale = data->scale * scale;
     
+	cube->setRenderScale(data->scale * scale);
 
-    btCollisionShape* shape;
+    btCollisionShape* boxShape;
     if (selectedMesh == wallSection) {
-        shape = new btBoxShape(btVector3(data->colliderScale.getX() / 2.0f, data->colliderScale.getZ() / 2.0f, data->colliderScale.getY() / 2.0f)* scale);
+        boxShape = new btBoxShape(btVector3(data->colliderScale.getX() / 2.0f, data->colliderScale.getZ() / 2.0f, data->colliderScale.getY() / 2.0f)* scale);
     }
     else {
-        shape = new btBoxShape(btVector3(data->colliderScale.getX() / 2.0f, data->colliderScale.getY() / 2.0f, data->colliderScale.getZ() / 2.0f)* scale);
+        boxShape = new btBoxShape(btVector3(data->colliderScale.getX() / 2.0f, data->colliderScale.getY() / 2.0f, data->colliderScale.getZ() / 2.0f)* scale);
     }
    
     // The object is penetrating the floor a bit, so I reduced the bullet collision margin to avoid sinking in the floor
-    shape->setMargin(0.01f);
+    boxShape->setMargin(0.01f);
+
+	btCompoundShape* compoundShape = new btCompoundShape();
+    btTransform colliderOffset;
+	colliderOffset.setIdentity();
+
+    // Check if it's a floor or not and apply the offset to the collider upward to align it with the mesh
+    if (!isFloor) {
+        colliderOffset.setOrigin(btVector3(0, (data->colliderPosition.getY() / 2.0f * scale) + 27, data->colliderScale.getZ() - 10.5));
+    }
+    else {
+        colliderOffset.setOrigin(btVector3(0, data->colliderPosition.getY(), 0));  // No offset for floor
+    }
+
+	compoundShape->addChildShape(colliderOffset, boxShape);
+
     // Setting the physics object for the cube
     cube->SetPhysicsObject(new PhysicsObject(cube));
-    cube->GetPhysicsObject()->InitBulletPhysics(bulletWorld, shape, 0, true);
-    // Setting render object
+    cube->GetPhysicsObject()->InitBulletPhysics(bulletWorld, compoundShape, 0, true);
     
     cube->SetRenderObject(new RenderObject(cube, selectedMesh, selectedTex, basicShader));
     world->AddGameObject(cube);


### PR DESCRIPTION
Fixed the wall collider issue by adjusting the collider’s position using a btCompoundShape to properly align it with the wall mesh. The collider was initially starting at the bottom of the mesh, so I added an offset to align it correctly, while ensuring that the floor mesh remained unaffected by the offset. Created a separate InitBulletPhysics method with btCompoundShape parameter instead of btCollisionShape for better collider handling since we will be doing a lot of exports from unity.