### PR TITLE
Use transparent search to remove old collision infos

### DIFF
--- a/CSC8503CoreClasses/CMakeLists.txt
+++ b/CSC8503CoreClasses/CMakeLists.txt
@@ -65,6 +65,7 @@ set(Physics
     "PhysicsObject.cpp"
     "PhysicsObject.h"
     "CustomCollisionCallback.h"
+    "CollisionInfo.cpp"
     "CollisionInfo.h"
 )
 source_group("Physics" FILES ${Physics})

--- a/CSC8503CoreClasses/CollisionInfo.cpp
+++ b/CSC8503CoreClasses/CollisionInfo.cpp
@@ -1,0 +1,16 @@
+#include "CollisionInfo.h"
+
+namespace NCL::CSC8503 {
+    bool operator<(const CollisionInfo& lhs, const CollisionInfo& rhs) {
+        return lhs.otherObject < rhs.otherObject;
+    }
+
+    bool operator<(const GameObject* lhs, const CollisionInfo& rhs) {
+        return lhs < rhs.otherObject;
+    }
+
+    bool operator<(const CollisionInfo& lhs, const GameObject* rhs) {
+        return lhs.otherObject < rhs;
+    }
+
+}

--- a/CSC8503CoreClasses/CollisionInfo.h
+++ b/CSC8503CoreClasses/CollisionInfo.h
@@ -14,45 +14,13 @@ namespace NCL::CSC8503 {
 		btVector3 relativeVelocity; // The relative velocity of the two objects
 
 		bool operator==(const CollisionInfo& other) const {
-			return otherObject == other.otherObject &&
-				   contactPointA == other.contactPointA &&
-				   contactPointB == other.contactPointB&&
-				   contactNormal == other.contactNormal&&
-				   penetrationDepth == other.penetrationDepth&&
-				   relativeVelocity == other.relativeVelocity;
-		} 
-	};
-}
-
-// hash function to generate a hash value for the CollisionInfo struct
-namespace std {
-	template<>
-	struct hash<btVector3> {
-		size_t operator()(const btVector3& v) const {
-			size_t h1 = hash<float>()(v.getX());
-			size_t h2 = hash<float>()(v.getY());
-			size_t h3 = hash<float>()(v.getZ());
-			return h1 ^ (h2 << 1) ^ (h3 << 2); // combine the hash values
+			return otherObject == other.otherObject;
 		}
 	};
 
-	template <>
-	struct hash<NCL::CSC8503::CollisionInfo> {
-		std::size_t operator()(const NCL::CSC8503::CollisionInfo& collision) const {
-			std::size_t hash = 0;
-			hash_combine(hash, collision.otherObject);
-			hash_combine(hash, collision.contactPointA);
-			hash_combine(hash, collision.contactPointB);
-			hash_combine(hash, collision.contactNormal);
-			hash_combine(hash, collision.penetrationDepth);
-			hash_combine(hash, collision.relativeVelocity);
-			return hash;
-		}
+	bool operator<(const CollisionInfo& lhs, const CollisionInfo& rhs);
 
-		template <typename T>
-		void hash_combine(std::size_t& seed, const T& v) const {
-			std::hash<T> hasher;
-			seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-		}
-	};
+	bool operator<(const GameObject* lhs, const CollisionInfo& rhs);
+
+	bool operator<(const CollisionInfo& lhs, const GameObject* rhs);
 }

--- a/CSC8503CoreClasses/CustomCollisionCallback.h
+++ b/CSC8503CoreClasses/CustomCollisionCallback.h
@@ -2,16 +2,13 @@
 
 #include "GameObject.h"
 #include "btBulletDynamicsCommon.h"
-#include "CustomCollisionCallback.h"
-#include <unordered_set>
+#include "CollisionInfo.h"
 
 namespace NCL {
 	namespace CSC8503 {
 		class CustomCollisionCallback : public btCollisionWorld::ContactResultCallback {
 		public:
-			// Using an unordered set to store the active collisions
-			// This set just stores detailed per-frame collision information and is temporary
-			std::unordered_set<CollisionInfo> activeCollisions;
+			std::set<CollisionInfo, std::less<>> activeCollisions;
 
 			CustomCollisionCallback(GameObject* parentObject) : parent(parentObject) {}
 
@@ -19,7 +16,7 @@ namespace NCL {
 			btScalar addSingleResult(btManifoldPoint& cp,
 				const btCollisionObjectWrapper* colObj0Wrap, int partId0, int index0,
 				const btCollisionObjectWrapper* colObj1Wrap, int partId1, int index1) override {
-				
+
 				GameObject* obj0 = (GameObject*)colObj0Wrap->getCollisionObject()->getUserPointer();
 				GameObject* obj1 = (GameObject*)colObj1Wrap->getCollisionObject()->getUserPointer();
 
@@ -40,9 +37,9 @@ namespace NCL {
 					// Print the contact points for debugging
 					//std::cout << "Contact Point A: " << contactPointA.getX() << " " << contactPointA.getY() << " " << contactPointA.getZ() << std::endl;
 					//std::cout << "Contact Point B: " << contactPointB.getX() << " " << contactPointB.getY() << " " << contactPointB.getZ() << std::endl;
-				
+
 					// Add the object's collision info to the active collisions set
-					
+
 					activeCollisions.insert(collisionInfo);
 				}
 

--- a/CSC8503CoreClasses/PhysicsObject.cpp
+++ b/CSC8503CoreClasses/PhysicsObject.cpp
@@ -154,13 +154,8 @@ void PhysicsObject::CheckCollisions(btDynamicsWorld* world)
 
 	// Remove objects that are no longer colliding
 	std::erase_if(activeCollisions, [&](GameObject* obj) {
-		for (const auto& collision : callback.activeCollisions) {
-			if (collision.otherObject == obj) {
-				return false; // Still colliding, don't remove
-			}
-		}
-		return true; // No longer colliding, remove
-		});
+		return callback.activeCollisions.find(obj) == callback.activeCollisions.end();
+	});
 }
 
 void PhysicsObject::ClearForces() {


### PR DESCRIPTION
This converts an O(n^2) operation into O(nlogn), and reduces CheckCollisions time from ~1.4ms to ~1.0ms on my machine