### PR TITLE
Scaled textures for cuboids

### DIFF
--- a/Assets/Shaders/scene.frag
+++ b/Assets/Shaders/scene.frag
@@ -47,7 +47,7 @@ void main(void)
 
     if(hasNormalMap) { //normal map additions
 	    mat3 TBN = mat3 (normalize(IN.tangent), normalize(IN.binormal), normalize(IN.normal));
-		mapnormal = texture(normalTex, IN.texCoord).rgb;
+		mapnormal = texture(normalTex, IN.texCoord).rgb; 
 		mapnormal = normalize(TBN * normalize(mapnormal * 2.0 - 1.0)); 
 		NORMAL = mapnormal;
 		}
@@ -64,7 +64,7 @@ void main(void)
 	vec4 albedo = IN.colour;
 	
 	if(hasTexture) {
-	 albedo *= texture(mainTex, IN.texCoord);
+	 albedo *= texture(mainTex, IN.texCoord); 
 	}
 
 	float attenuation = 1.0f; //default attenuation value 

--- a/Assets/Shaders/scene.vert
+++ b/Assets/Shaders/scene.vert
@@ -16,6 +16,10 @@ uniform vec4 objectColour;
 
 uniform bool hasVertexColours = false;
 uniform bool isFlat = false;
+uniform float texScaleX;
+uniform float texScaleY;
+uniform float texScaleZ;
+uniform bool  texRepeating;
 
 out Vertex
 {
@@ -31,6 +35,31 @@ out Vertex
 
 void main(void)
 {
+    vec2 TEXCOORD = texCoord; 
+	//before applying mvp matrix, vertices are in local space and therefore axis aligned
+	//We check to see what axis the plane in question is facing before determining how to scale the texCoords
+	//Scaling currently works well for cuboids but not too well for curved surfaces like capsules and spheres
+	vec3 direction = normalize(normal);
+	if (abs(direction.x) > 0.001 && abs(direction.y) < 0.001 && abs(direction.z) < 0.001) {//face is perpendicular to x plane => on y-z plane
+	   
+	    TEXCOORD.x *= texScaleZ;
+	    TEXCOORD.y *= texScaleY;
+    }
+	if (abs(direction.y) > 0.001 && abs(direction.x) < 0.001 && abs(direction.z) < 0.001) {//face is perpendicular to y plane => on x-z plane
+	 
+	    TEXCOORD.x *= texScaleX;
+	    TEXCOORD.y *= texScaleZ;
+    }
+	if (abs(direction.z) > 0.001 && abs(direction.x) < 0.001 && abs(direction.y) < 0.001) {//face is perpendicular to z plane => on x-y plane
+	    TEXCOORD.x *= texScaleX;
+	    TEXCOORD.y *= texScaleY;
+	   }
+    if (!texRepeating) { //if texture not to be repeated or scaled then just take original texture coordinates
+	   TEXCOORD = texCoord;
+	   }
+
+	   OUT.texCoord = TEXCOORD; 
+
 	mat4 mvp 		  = (projMatrix * viewMatrix * modelMatrix);
 	mat3 normalMatrix = transpose ( inverse ( mat3 ( modelMatrix )));
 
@@ -39,7 +68,6 @@ void main(void)
 	OUT.normal 		= normalize ( normalMatrix * normalize ( normal ));
 	OUT.tangent     = normalize ( normalMatrix * normalize ( tangent.xyz)); //calculate tangent for normal mapping
 	OUT.binormal    = cross ( OUT.tangent, OUT.normal) * OUT.tangent; //calculate the binormal for normal mapping
-	OUT.texCoord	= texCoord;
 	OUT.colour		= objectColour;
 	gl_Position		= mvp * vec4(position, 1.0);
 }

--- a/CSC8503CoreClasses/RenderObject.h
+++ b/CSC8503CoreClasses/RenderObject.h
@@ -64,6 +64,22 @@ namespace NCL {
 				return normalMap.get();
 			}
 
+			bool GetTexRepeating() const {
+				return texRepeating;
+			}
+
+			void SetTexRepeating(bool tr) {
+				texRepeating = tr;
+			}
+
+			float GetTexScaleMultiplier() const {
+				return texScaleMultiplier;
+			}
+
+			void SetTexScaleMultiplier(float f) { //in case an individual object's texture scale needs to be modified
+				texScaleMultiplier = f;
+			}
+
 		protected:
 			GameObject* parent;
 			std::shared_ptr<Mesh> mesh;
@@ -71,6 +87,8 @@ namespace NCL {
 			std::shared_ptr<Shader> shader;
 			Vector4		colour = Vector4(1, 1, 0, 0.99);
 			bool isFlat = false;
+			bool texRepeating = false; // added to allow repeating textures per object
+			float texScaleMultiplier = 0.1f; //unless set to something else, all scaled textures will be scaled with this and their renderScale
 			//additional normal map option:
 			std::shared_ptr<Texture> normalMap;
 		};

--- a/TeamProject/GameTechRenderer.cpp
+++ b/TeamProject/GameTechRenderer.cpp
@@ -150,7 +150,7 @@ void GameTechRenderer::RenderFrame() {
 	glDisable(GL_DEPTH_TEST);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	NewRenderLines();
-	NewRenderTextures();
+	NewRenderTextures(); 
 	NewRenderText();
 	glDisable(GL_BLEND);
 	glEnable(GL_DEPTH_TEST);
@@ -259,6 +259,7 @@ void GameTechRenderer::RenderCamera() {
 	int shadowLocation  = 0;
 	int hasFlatLocation = 0;
 	int hasNormalLocation = 0;
+	int texRepeatingLocation = 0; 
 
 	int lightPosLocation	= 0;
 	int lightColourLocation = 0;
@@ -274,8 +275,17 @@ void GameTechRenderer::RenderCamera() {
 		OGLShader* shader = (OGLShader*)(*i).GetShader();
 		UseShader(*shader);
 
-		if ((*i).GetDefaultTexture()) {
+		if ((*i).GetDefaultTexture()) { 
 			BindTextureToShader(*(OGLTexture*)(*i).GetDefaultTexture(), "mainTex", 0);
+			//figure out scale of object:
+			float multiplier = (*i).GetTexScaleMultiplier();   
+			float scaleX = (*i).getParent()->getRenderScale().x*multiplier;
+			float scaleY = (*i).getParent()->getRenderScale().y*multiplier;
+			float scaleZ = (*i).getParent()->getRenderScale().z*multiplier; 
+			glUniform1f(glGetUniformLocation(shader->GetProgramID(), "texScaleX"), scaleX);
+			glUniform1f(glGetUniformLocation(shader->GetProgramID(), "texScaleY"), scaleY);
+			glUniform1f(glGetUniformLocation(shader->GetProgramID(), "texScaleZ"), scaleZ);
+			
 		}
 
 		//normal map capabilities added:
@@ -293,6 +303,7 @@ void GameTechRenderer::RenderCamera() {
 			hasTexLocation  = glGetUniformLocation(shader->GetProgramID(), "hasTexture");
 			hasFlatLocation =  glGetUniformLocation(shader->GetProgramID(), "isFlat");
 			hasNormalLocation = glGetUniformLocation(shader->GetProgramID(), "hasNormalMap");
+			texRepeatingLocation = glGetUniformLocation(shader->GetProgramID(), "texRepeating");
 
 			lightPosLocation	= glGetUniformLocation(shader->GetProgramID(), "lightPos");
 			lightColourLocation = glGetUniformLocation(shader->GetProgramID(), "lightColour");
@@ -333,6 +344,7 @@ void GameTechRenderer::RenderCamera() {
 		glUniform1i(hasTexLocation, (OGLTexture*)(*i).GetDefaultTexture() ? 1:0);
 		glUniform1i(hasFlatLocation, i->GetIsFlat());
 		glUniform1i(hasNormalLocation, i->GetHasNormal());
+		glUniform1i(texRepeatingLocation, i->GetTexRepeating());
 	
 		BindMesh((OGLMesh&)*(*i).GetMesh());
 		size_t layerCount = (*i).GetMesh()->GetSubMeshCount();

--- a/TeamProject/LevelImporter.cpp
+++ b/TeamProject/LevelImporter.cpp
@@ -135,4 +135,5 @@ void LevelImporter::AddObjectToWorld(ObjectData* data) {
     ));
     world->AddGameObject(cube);
     cube->setIsFloor(true);
+    cube->GetRenderObject()->SetTexRepeating(true);//sets texture to repeat and scale
 }

--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -258,7 +258,7 @@ void TutorialGame::InitPlayer() {
 	player->GetPhysicsObject()->GetRigidBody()->setAngularFactor(0);
 	player->GetPhysicsObject()->GetRigidBody()->setFriction(0.0f);
 	player->GetPhysicsObject()->GetRigidBody()->setDamping(0.0, 0);
-	gun = AddCubeToWorld(Vector3(10, 2, 20), Vector3(0.6, 0.6, 1.6), 0, false);
+	gun = AddCubeToWorld(Vector3(10, 2, 20), Vector3(0.6, 0.6, 1.6), 0, false); 
 	playerController = new PlayerController(player, gun, controller, mainCamera, bulletWorld, world, resourceManager.get());
 	player->GetRenderObject()->SetColour(playerColour);
 
@@ -318,6 +318,7 @@ GameObject* TutorialGame::AddCubeToWorld(const Vector3& position, Vector3 dimens
 
 	// Setting render object
 	cube->SetRenderObject(new RenderObject(cube, resourceManager->getMeshes().get("Cube.msh"), defaultTexture, defaultShader));
+	cube->GetRenderObject()->SetTexRepeating(true); //scale texture (no stretching)
 
 	world->AddGameObject(cube);
 
@@ -387,6 +388,7 @@ GameObject* TutorialGame::AddInfinitePlaneToWorld(const Vector3& position, const
 
 	// Set the render object
 	plane->SetRenderObject(new RenderObject(plane, resourceManager->getMeshes().get("Plane.msh"), defaultTexture, defaultShader));
+	plane->GetRenderObject()->SetTexRepeating(true); //scale texture
 
 	// Set the physics object
 	plane->SetPhysicsObject(new PhysicsObject(plane));


### PR DESCRIPTION
Set Cuboid (and plane) textures to scale such that all cuboid objects with the same texture will look the same such that the texture is never stretched and appears the same size on any of those objects. Does not work too well with curved surfaces so currently only applied to cuboids and planes.