### PR TITLE
Fixed Out-of-Bounds Index for Contacts Manifolds

### DIFF
--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -208,6 +208,12 @@ void TutorialGame::CheckCollisions()
 	int numManifolds = dispatcher->getNumManifolds();
 
 	for (int i = 0; i < numManifolds; i++) {
+		// The UpdateGame loop may be using a faster an outdated number of manifolds
+		// So, we need to check if the index is still valid
+		if (i >= dispatcher->getNumManifolds()) {
+			break;
+		}
+
 		// Get the contact manifold
 		btPersistentManifold* contactManifold = dispatcher->getManifoldByIndexInternal(i);
 


### PR DESCRIPTION
Bullet may be manipulating the manifold list while we are iterating over the manifolds resulting in out-of-bounds index.

This fixes the issue where the game was shutting down after a certain time and frequent firing of paintballs.