### PR TITLE
Fixed floor-detect bug

### DIFF
--- a/TeamProject/PlayerObject.h
+++ b/TeamProject/PlayerObject.h
@@ -21,7 +21,7 @@ public:
 		btVector3 direction = (objPos - playerPos).normalized();
 		float dot = direction.dot(-upDirection);
 		float angle = acos(dot) * (180.0f / SIMD_PI);
-		if (angle <= 30.0f) {
+		if (angle <= 25.0f) {
 			collided++;
 			collidedObjects.push_back(collisionInfo.otherObject);
 		}
@@ -46,7 +46,7 @@ public:
 		float angle = acos(dot) * (180.0f / SIMD_PI);
 		auto it = std::find(collidedObjects.begin(), collidedObjects.end(), collision.otherObject);
 		if (it != collidedObjects.end()) { // contains already
-			if (angle >= 30.0f) { // now too steep for floor
+			if (angle > 25.0f) { // now too steep for floor
 				collidedObjects.erase(it);
 				if (collided > 0) {
 					collided--;
@@ -54,7 +54,7 @@ public:
 			}
 		}
 		else { // not counted as floor yet
-			if (angle <= 30.0f) {
+			if (angle <= 25.0f) {
 				collided++;
 				collidedObjects.push_back(collision.otherObject);
 			}


### PR DESCRIPTION
Player got caught on flat cubes next to each other when falling- decreased floor angle detect enough to still work with slopes but stop this issue.