### PR TITLE
Fixed Player Passing Through the Wall

### DIFF
--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -310,6 +310,7 @@ void TutorialGame::InitPlayer() {
 	}
 	// Keep us from clipping when falling too fast
 	player->GetPhysicsObject()->GetRigidBody()->setCcdMotionThreshold(1.0f);
+	player->GetPhysicsObject()->GetRigidBody()->setCcdSweptSphereRadius(0.4f);
 	player->GetPhysicsObject()->GetRigidBody()->setAngularFactor(0);
 	player->GetPhysicsObject()->GetRigidBody()->setFriction(0.0f);
 	player->GetPhysicsObject()->GetRigidBody()->setDamping(0.0, 0);


### PR DESCRIPTION
Player misses the wall sometimes on high fps, fixed it by setting a swept sphere radius.