### PR TITLE
Use `Auto` for image2gnf format

### DIFF
--- a/cmake/copy_assets.cmake
+++ b/cmake/copy_assets.cmake
@@ -1,4 +1,5 @@
 set(TEXTURE_EXTENSIONS ".jpg" ".png" ".dds")
+set(MIP_LEVELS 8)
 
 macro(process_file)
     set(outvar ${ARGV0})
@@ -20,7 +21,7 @@ macro(process_file)
         list(APPEND PROCESSED_ASSETS ${file}.gnf)
         add_custom_command(
             OUTPUT ${file}.gnf
-            COMMAND image2gnf -g 1 -i ${file} -o ${file}.gnf -f Auto
+            COMMAND image2gnf -g 1 -i ${file} -o ${file}.gnf -f Auto --mipmaps ${MIP_LEVELS}
             DEPENDS ${file}
         )
     elseif(${extension} STREQUAL ".pssl" AND PS5_BUILD)

--- a/cmake/copy_assets.cmake
+++ b/cmake/copy_assets.cmake
@@ -20,7 +20,7 @@ macro(process_file)
         list(APPEND PROCESSED_ASSETS ${file}.gnf)
         add_custom_command(
             OUTPUT ${file}.gnf
-            COMMAND image2gnf -g 1 -i ${file} -o ${file}.gnf -f Bc1UNorm
+            COMMAND image2gnf -g 1 -i ${file} -o ${file}.gnf -f Auto
             DEPENDS ${file}
         )
     elseif(${extension} STREQUAL ".pssl" AND PS5_BUILD)


### PR DESCRIPTION
`Bc1Unorm` requires exactly 3 channels, which some textures don't have. `Auto` selects automatically and can handle all of our current textures.