### PR TITLE
Add return values for missed control paths.

### DIFF
--- a/TeamProject/Multiplayer/Lobby.cpp
+++ b/TeamProject/Multiplayer/Lobby.cpp
@@ -4,6 +4,7 @@ namespace Lobbies {
 	bool UserColor::SetUser(const User& user) {
 		if (m_assigned.has_value()) return false;
 		m_assigned.emplace(user);
+		return true;
 	}
 
 
@@ -17,6 +18,7 @@ namespace Lobbies {
 	bool Lobby::AddUser(const User& user) {
 		if (m_players.size() >= m_maxSize) return false;
 		m_players.insert(std::make_pair(user.GetUserID(), user));
+		return true;
 	}
 
 	bool Lobby::AreAllPlayersAssignedColor() const {


### PR DESCRIPTION
UserColor::SetUser and Lobby::AddUser did not return true upon success. This has been fixed.