### PR TITLE
fixed fragment shader to enhance decal appearance

### DIFF
--- a/Assets/Shaders/decal.frag
+++ b/Assets/Shaders/decal.frag
@@ -9,18 +9,15 @@ uniform float alphaFade;
 
 void main() {
     vec4 decalColor = texture(decalTexture, TexCoord);
-    //if (decalColor.a < 0.1) discard; // Discard transparent fragments
+    if (decalColor.a < 0.1) discard; // Discard transparent fragments
+
+    // Apply gamma correction as the decal looks washed out (coz of linear-space lighting calculations)
+    // This is a simple approximation of the sRGB color space (which is the default color space for most monitors)
+    decalColor.rgb = pow(decalColor.rgb, vec3(2.2));
 
     // Reduce alpha over time for fading effect
-    decalColor.a = max(decalColor.a - alphaFade, 0.0);
+    decalColor.a *= alphaFade;
 
     // Output final color
-    //FragColor = decalColor;
-    
-    // Debug output (red = missing texture, green = valid UVs)
-    if (decalColor.rgb == vec3(0.0)) {
-        FragColor = vec4(1.0, 0.0, 0.0, 1.0); // Red if texture fails
-    } else {
-        FragColor = vec4(0.0, 1.0, 0.0, 1.0); // Green if UVs work
-    }
+    FragColor = decalColor;
 }

--- a/TeamProject/DecalSystem.h
+++ b/TeamProject/DecalSystem.h
@@ -32,6 +32,8 @@ namespace NCL {
 
 			const std::vector<Decal>& GetDecals() const { return decals; }
 
+			void ClearDecalsFromWorld() { decals.clear(); }
+
 		private:
 			GLuint decalFBO;
 			GLuint decalTexture;

--- a/TeamProject/PlayerController.cpp
+++ b/TeamProject/PlayerController.cpp
@@ -198,7 +198,7 @@ void PlayerController::Shoot() {
         }
 
         if (hitObj != nullptr) { // hit an object of some kind
-            hitObj->GetRenderObject()->SetColour(hitObj->GetRenderObject()->GetColour() * Vector4(1.05f, 0.95f, 0.95f, 1.0f));
+            //hitObj->GetRenderObject()->SetColour(hitObj->GetRenderObject()->GetColour() * Vector4(1.05f, 0.95f, 0.95f, 1.0f));
 
 			// Convert Normal and Hit Point from Bullet's btVector3 to NCL::Maths::Vector3
 			NCL::Maths::Vector3 normal(hitNormal.getX(), hitNormal.getY(), hitNormal.getZ());

--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -304,6 +304,7 @@ void TutorialGame::InitWorld() {
 	world->ClearAndErase();
 	InitBullet();
 	audioEngine.Init();
+	renderer->GetDecalSystem().ClearDecalsFromWorld();
 
 	navMeshDebug = false;
 	if (navMeshDebug) {


### PR DESCRIPTION
Made some minor changed in the fragment shader. Applied gamma correction to decal's rgb as the decal looks washed out due to png texture being in sRGB color space but the shader assuming linear space.

Removed/Commented out setting red color to the mesh after paintball hits.