### PR TITLE
Shooting ray from the camera pos instead of player pos

### DIFF
--- a/TeamProject/PlayerController.cpp
+++ b/TeamProject/PlayerController.cpp
@@ -173,9 +173,9 @@ void PlayerController::Shoot() {
     btMatrix3x3 rotationMatrix(bulletRotation);
 
     btVector3 forwardDir = rotationMatrix * btVector3(0, 0, -1);
-    btVector3 forwardPos = (btPlayerPos + (forwardDir * 10000));
-    btCollisionWorld::AllHitsRayResultCallback callback(btPlayerPos, forwardPos);
-    bulletWorld->rayTest(btPlayerPos, forwardPos, callback);
+    btVector3 forwardPos = (camera->GetPosition() + (forwardDir * 10000));
+    btCollisionWorld::AllHitsRayResultCallback callback(camera->GetPosition(), forwardPos);
+    bulletWorld->rayTest(camera->GetPosition(), forwardPos, callback);
     
     btVector3 hitPoint = btVector3();
 	btVector3 hitNormal = btVector3(0, 1, 0); // Default normal (up)


### PR DESCRIPTION
The ray for shooting needs to be fired from the camera's position (as crosshair is at the center of the screen) instead of player's position.

The above fix has been made in this commit and the decal's are spawning correctly where the crosshair is aiming.