### PR TITLE
Fixes spatial audio coming through one side problem

### DIFF
--- a/TeamProject/AudioEngine.cpp
+++ b/TeamProject/AudioEngine.cpp
@@ -136,6 +136,18 @@ void CAudioEngine::SetChannel3dPosition(int nChannelId, const NCL::Maths::Vector
     CAudioEngine::ErrorCheck(tFoundIt->second->set3DAttributes(&position, NULL));
 }
 
+void CAudioEngine::Set3dListenerAndOrientation(const NCL::Maths::Vector3& vPosition, const NCL::Maths::Vector3& vLook, const NCL::Maths::Vector3& vUp) {
+    FMOD_VECTOR fmodPosition = VectorToFmod(vPosition);
+    FMOD_VECTOR fmodLook = VectorToFmod(vLook);
+    FMOD_VECTOR fmodUp = VectorToFmod(vUp);
+
+    FMOD_VECTOR fmodVelocity = { 0.0f, 0.0f, 0.0f }; // Velocity is usually needed for Doppler effect, but we don't have it here
+
+    if (sgpImplementation && sgpImplementation->mpSystem) {
+        sgpImplementation->mpSystem->set3DListenerAttributes(0, &fmodPosition, &fmodVelocity, &fmodLook, &fmodUp);
+    }
+}
+
 //Sets the volume of an FMod channel
 void CAudioEngine::SetChannelVolume(int nChannelId, float fVolumedB) {
     auto tFoundIt = sgpImplementation->mChannels.find(nChannelId);

--- a/TeamProject/PlayerController.cpp
+++ b/TeamProject/PlayerController.cpp
@@ -429,6 +429,9 @@ void PlayerController::CalculateDirections(float dt) {
     rightDirection = CalculateRightDirection(upDirection);
     forwardDirection = CalculateForwardDirection(upDirection, rightDirection);
     player->setUpDirection(upDirection);
+
+    //Update FMod listener each frame so audio is correctly positioned
+    audioEngine.Set3dListenerAndOrientation(player->GetTransform().getOrigin(), forwardDirection, upDirection);
 }
 
 btVector3 PlayerController::CalculateUpDirection(float dt) {

--- a/TeamProject/PlayerController.h
+++ b/TeamProject/PlayerController.h
@@ -50,6 +50,14 @@ namespace NCL {
 				return upDirection;
 			}
 
+			btVector3 getRightDirection() {
+				return rightDirection;
+			}
+
+			btVector3 getForwardDirection() {
+				return forwardDirection;
+			}
+
 			float getYaw() {
 				return yaw;
 			}

--- a/TeamProject/main.cpp
+++ b/TeamProject/main.cpp
@@ -72,6 +72,7 @@ class GameScreen : public PushdownState {
 			pauseReminder = 0;
 			*newState = new PauseScreen();
 			return PushdownResult::Push;
+			//std::cout << "Game entered pause state \n";
 		}
 		if (Window::GetKeyboard()->KeyPressed(NCL::KeyCodes::RCONTROL)) {
 			Debug::Print("Going back to main menu", Vector2(0.1f, 0.3f), Vector4(0, 0, 0, 1));


### PR DESCRIPTION
Defined a function Set3dListenerAndOrientation and used playerController functions to calculate the up vector and the forward vector each frame, seems to have fixed the problem in my testing