### PR TITLE
Don't use bullet workaround on PS5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 # PS5 support requires a couple patches
 [submodule "ThirdParty/bullet3"]
 	path = ThirdParty/bullet3
-	url = https://github.com/kieranknowles1/bullet3
+	url = https://github.com/bulletphysics/bullet3
 [submodule "ThirdParty/nlohmann_json"]
 	path = ThirdParty/nlohmann_json
 	url = https://github.com/nlohmann/json


### PR DESCRIPTION
This wasn't necessary, we just had to link against the correct library