### PR TITLE
Up direction moved

### DIFF
--- a/TeamProject/CMakeLists.txt
+++ b/TeamProject/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     PlayerController.cpp
     PlayerController.h
     PlayerObject.h
+    PlayerObject.cpp
     Turret.h
     Turret.cpp
 	BWHelperFunctions.h

--- a/TeamProject/PlayerController.cpp
+++ b/TeamProject/PlayerController.cpp
@@ -34,17 +34,13 @@ btVector3 GetEulerAngles(btQuaternion quat) {
 void PlayerController::UpdateMovement(float dt) {
     transformPlayer = rb->getWorldTransform();
     btPlayerPos = transformPlayer.getOrigin();
-
+    GetAllDirections();
     HandleShooting(dt);
 
-    // yaw is fully local
     yaw = fmod(yaw - controller->GetAnalogue(Controller::AnalogueControl::LookX) + 360.0f, 360.0f);
     camera->SetYaw(yaw);
-
-    //camera offset for rotation
     btVector3 rot = GetEulerAngles(camRotOffset);
     camera->setRotation(rot);
-
     HandleTypes();
 
     //sliding/floor detection
@@ -126,6 +122,7 @@ void PlayerController::UpdateMovement(float dt) {
         player->setCollided(0);
         inAirTime = 0.2f;
     }
+
     previousVelocity = rb->getLinearVelocity();
     rb->setLinearVelocity(movement);
     rb->activate();
@@ -161,7 +158,6 @@ void PlayerController::HandleShooting(float dt) {
         shotTimer += dt;
     }
 }
-
 
 
 void PlayerController::Shoot() {
@@ -412,115 +408,14 @@ void PlayerController::HandleTypes() {
 }
 
 
-// world rotate things
-void PlayerController::Rotate(bool positive, bool rolling) {
-    if (rotationChanging) return;
-    btVector3 rightDirections = (rolling ? CalculateForwardFromYaw() : CalculateRightFromYaw());
-    btQuaternion pitchQuat(rightDirections, Maths::DegreesToRadians(positive ? 90 : -90));
-    targetWorldRotation = quatRotate(pitchQuat, upDirection);
-    targetcamRotOffset = pitchQuat * oldcamRotOffset; // Apply rotation correctly
-    rotationChanging = true;
-}
-
-void PlayerController::CalculateDirections(float dt) {
-    upDirection = CalculateUpDirection(dt);
-    rightDirection = CalculateRightDirection(upDirection);
-    forwardDirection = CalculateForwardDirection(upDirection, rightDirection);
-    player->setUpDirection(upDirection);
+void PlayerController::GetAllDirections() {
+    upDirection = player->getUpDirection();
+    rightDirection = player->getForwardDirection();
+    forwardDirection = player->getRightDirection();
+    camRotOffset = player->getCamOffset();
 
     //Update FMod listener each frame so audio is correctly positioned
     audioEngine.Set3dListenerAndOrientation(camera->GetPosition(), forwardDirection, upDirection);
-}
-
-btVector3 PlayerController::CalculateUpDirection(float dt) {
-
-    btVector3 upDir;
-    if (!rotationChanging) {
-        upDir = targetWorldRotation;
-        camRotOffset = targetcamRotOffset;
-
-    }else if (rotateTimer <= rotateTime && rotationChanging) {
-        rotateTimer += dt;
-        upDir = lerp(oldWorldRotation, targetWorldRotation,  rotateTimer/rotateTime);
-        camRotOffset = (oldcamRotOffset.slerp(targetcamRotOffset, rotateTimer / rotateTime));
-    }
-    else {
-        upDir = targetWorldRotation;
-        camRotOffset = targetcamRotOffset;
-        oldcamRotOffset = targetcamRotOffset;
-        oldWorldRotation = targetWorldRotation;
-        rotationChanging = false;
-        rotateTimer = 0.0f;
-    }
-    upDir.normalize();
-    return upDir;
-}
-
-btVector3 PlayerController::CalculateRightDirection(btVector3 upDir) {
-    btVector3 forward = btVector3(0, 0, 1);
-    if (fabs(upDir.dot(forward)) > 0.999f) {
-        forward = btVector3(0, 1, 0);
-    }
-    btVector3 rightDirection = upDir.cross(forward);
-    rightDirection.normalize();
-  //  std::cout << rightDirection << std::endl;
-    return rightDirection;
-}
-
-btVector3 PlayerController::CalculateForwardDirection(btVector3 upDir,btVector3 rightDir) {
-    btVector3 forwardDirection = rightDir.cross(upDir);
-    forwardDirection.normalize();
-    return forwardDirection;
-}
-
-btVector3 PlayerController::CalculateForwardFromYaw() {
-    int snappedYaw = static_cast<int>((yaw + 45) / 90) * 90 % 360;
-    btVector3 forwd = btVector3(0, 0, 0);
-    switch (snappedYaw) {
-    case 0: {
-        forwd = btVector3(0, 0, 1);
-        break;
-    }
-    case 90: {
-        forwd = btVector3(1, 0, 0);
-        break;
-    }
-    case 180: {
-        forwd = btVector3(0, 0, -1);
-        break;
-    }
-    case 270: {
-        forwd = btVector3(-1, 0, 0);
-        break;
-    }
-    }
-    btVector3 baseForward = quatRotate(oldcamRotOffset, forwd);
-    return baseForward;
-}
-
-btVector3 PlayerController::CalculateRightFromYaw() {
-    int snappedYaw = static_cast<int>((yaw + 45) / 90) * 90 % 360;
-    btVector3 right = btVector3(0, 0, 0);
-    switch (snappedYaw) {
-    case 0: {
-        right = btVector3(1, 0, 0);
-        break;
-    }
-    case 90: {
-        right = btVector3(0, 0, -1);
-        break;
-    }
-    case 180: {
-        right = btVector3(-1, 0, 0);
-        break;
-    }
-    case 270: {
-        right = btVector3(0, 0, 1);
-        break;
-    }
-    }
-    btVector3 baseForward = quatRotate(oldcamRotOffset, right);
-    return baseForward;
 }
 
 Vector2 PlayerController::getDirectionalInput() const

--- a/TeamProject/PlayerController.cpp
+++ b/TeamProject/PlayerController.cpp
@@ -36,14 +36,8 @@ void PlayerController::UpdateMovement(float dt) {
     btPlayerPos = transformPlayer.getOrigin();
     GetAllDirections();
     HandleShooting(dt);
-
-    yaw = fmod(yaw - controller->GetAnalogue(Controller::AnalogueControl::LookX) + 360.0f, 360.0f);
-    camera->SetYaw(yaw);
-    btVector3 rot = GetEulerAngles(camRotOffset);
-    camera->setRotation(rot);
-    HandleTypes();
-
-    //sliding/floor detection
+    HandleYaw();
+    SpecialTypeCalculations();
     HandleSliding(dt);
     HandleCrouching(dt);
 
@@ -51,82 +45,17 @@ void PlayerController::UpdateMovement(float dt) {
         player->setCollided(0);
         inAirTime -= dt;
     }
-
     if ((isSliding||slideTransition) && !isCrouching) return;
 
-    //player rotation
-    btQuaternion playerYaw = btQuaternion(btVector3(0, 1, 0), Maths::DegreesToRadians(yaw));
-    btQuaternion finalRotation = camRotOffset * playerYaw;
-    transformPlayer.setRotation(finalRotation);
-    rb->setWorldTransform(transformPlayer);
-
-    //camera follows player, lowers if crouching
-    btTransform transformPlayerMotion;
-    player->GetPhysicsObject()->GetMotionState()->getWorldTransform(transformPlayerMotion);
-    btVector3 playerCamPos = transformPlayerMotion.getOrigin();
-    playerCamPos += upDirection * (isCrouching ? std::lerp(cameraHeight, crouchHeight, btMin(currentCrouchingTimer / crouchingTime, 1.0f)) : std::lerp(crouchHeight, cameraHeight, btMin(currentStandingTimer / crouchingTime, 1.0f)));
-    if (!slideTransition && !thirdPerson) {
-        camera->SetPosition(playerCamPos);
-        SetGunTransform();
-    }
-
-    //finds player forward and right vectors
-    btMatrix3x3 rotationMatrix(finalRotation);
-    btVector3 forward = rotationMatrix * btVector3(0, 0, -1);
-    btVector3 up = rotationMatrix * btVector3(0, 1, 0);
-    btVector3 right = rotationMatrix * btVector3(1, 0, 0);
-
-    //if on ground, movement based on floor angle
-    if (player->getCollided() > 0) {
-        btVector3 groundNormal = FindFloorNormal();
-        if (groundNormal != btVector3(0, 0, 0)) {
-            float cosAngleThreshold = cos(btRadians(50.0f));
-            float dotProduct = groundNormal.dot(upDirection.absolute());
-            if (fabs(dotProduct) >= cosAngleThreshold && fabs(dotProduct) <= 1.0f) {
-                btVector3 slopeForward = forward - (forward.dot(groundNormal)) * groundNormal;
-                slopeForward.normalize();
-                btVector3 slopeRight = right - (right.dot(groundNormal)) * groundNormal;
-                slopeRight.normalize();
-                if (slopeForward.length2() > SIMD_EPSILON && slopeRight.length2() > SIMD_EPSILON) {
-                    forward = slopeForward;
-                    right = slopeRight;
-                }
-            }
-        }
-    }
-
-    //movement based on all the multipliers combined
-    Vector2 directionalInput = getDirectionalInput();
-    bool sprinting = controller->GetDigital(Controller::DigitalControl::Sprint);
-    float forwardMovement = directionalInput.y;
-    float moveMulti = playerSpeed * (sprinting ? sprintMulti : 1) * (isCrouching ? crouchMulti : 1) * (player->getCollided() <= 0 ? airMulti : 1);
-    forwardMovement *= (forwardMovement <= 0) ? backwardsMulti : 1;
-    btVector3 movement = (right * directionalInput.x * strafeMulti * moveMulti ) +(forward * forwardMovement * moveMulti);
-
-    if (player->getCollided() <= 0 || onIce) {
-        movement *= (airMulti*dt);
-        movement += rb->getLinearVelocity();
-    }
-
-    // jump input
-    if (controller->GetDigital(Controller::DigitalControl::Jump) && player->getCollided() && inAirTime <= 0) {
-        audioEngine.PlaySounds("jump.wav", camera->GetPosition(), 0.0f);
-        btVector3 normal = FindFloorNormal();
-        float dotProduct = normal.dot(upDirection.absolute());
-        if (fabs(dotProduct <= 1)) {
-            movement += (jumpHeight * normal);
-        }
-        else {
-            movement += (jumpHeight * upDirection);
-        }
-        player->setCollided(0);
-        inAirTime = 0.2f;
-    }
+    RotationCalculations();
+    CameraMovement();
+    GroundNormalCalculations();
+    MovementCalculations(dt);
+    HandleJumping();
 
     previousVelocity = rb->getLinearVelocity();
     rb->setLinearVelocity(movement);
     rb->activate();
-
 }
 
 
@@ -358,7 +287,7 @@ void PlayerController::HandleSliding(float dt) {
     }
 }
 
-void PlayerController::HandleTypes() {
+void PlayerController::SpecialTypeCalculations() {
     switch (player->getType())
     {
     case 'D': //Default
@@ -406,6 +335,92 @@ void PlayerController::HandleTypes() {
     }
     player->resetType();
 }
+
+void PlayerController::HandleYaw() {
+    yaw = fmod(yaw - controller->GetAnalogue(Controller::AnalogueControl::LookX) + 360.0f, 360.0f);
+    camera->SetYaw(yaw);
+    btVector3 rot = GetEulerAngles(camRotOffset);
+    camera->setRotation(rot);
+}
+
+void PlayerController::RotationCalculations() {
+    //player rotation based on yaw
+    btQuaternion playerYaw = btQuaternion(btVector3(0, 1, 0), Maths::DegreesToRadians(yaw));
+    btQuaternion finalRotation = camRotOffset * playerYaw;
+    transformPlayer.setRotation(finalRotation);
+    rb->setWorldTransform(transformPlayer);
+    //finds player forward and right vectors
+    btMatrix3x3 rotationMatrix(finalRotation);
+    forward = rotationMatrix * btVector3(0, 0, -1);
+    up = rotationMatrix * btVector3(0, 1, 0);
+    right = rotationMatrix * btVector3(1, 0, 0);
+
+};
+
+//camera follows player, lowers if crouching, don't change if third person
+void PlayerController::CameraMovement() {
+    btTransform transformPlayerMotion;
+    player->GetPhysicsObject()->GetMotionState()->getWorldTransform(transformPlayerMotion);
+    btVector3 playerCamPos = transformPlayerMotion.getOrigin();
+    playerCamPos += upDirection * (isCrouching ? std::lerp(cameraHeight, crouchHeight, btMin(currentCrouchingTimer / crouchingTime, 1.0f)) : std::lerp(crouchHeight, cameraHeight, btMin(currentStandingTimer / crouchingTime, 1.0f)));
+    if (!slideTransition && !thirdPerson) {
+        camera->SetPosition(playerCamPos);
+        SetGunTransform();
+    }
+};
+
+//if on ground, movement based on floor angle
+void PlayerController::GroundNormalCalculations() {
+    if (player->getCollided() > 0) {
+        btVector3 groundNormal = FindFloorNormal();
+        if (groundNormal != btVector3(0, 0, 0)) {
+            float cosAngleThreshold = cos(btRadians(50.0f));
+            float dotProduct = groundNormal.dot(upDirection.absolute());
+            if (fabs(dotProduct) >= cosAngleThreshold && fabs(dotProduct) <= 1.0f) {
+                btVector3 slopeForward = forward - (forward.dot(groundNormal)) * groundNormal;
+                slopeForward.normalize();
+                btVector3 slopeRight = right - (right.dot(groundNormal)) * groundNormal;
+                slopeRight.normalize();
+                if (slopeForward.length2() > SIMD_EPSILON && slopeRight.length2() > SIMD_EPSILON) {
+                    forward = slopeForward;
+                    right = slopeRight;
+                }
+            }
+        }
+    }
+};
+
+//movement based on all the multipliers combined
+void PlayerController::MovementCalculations(float dt) {
+    Vector2 directionalInput = getDirectionalInput();
+    bool sprinting = controller->GetDigital(Controller::DigitalControl::Sprint);
+    float forwardMovement = directionalInput.y;
+    float moveMulti = playerSpeed * (sprinting ? sprintMulti : 1) * (isCrouching ? crouchMulti : 1) * (player->getCollided() <= 0 ? airMulti : 1);
+    forwardMovement *= (forwardMovement <= 0) ? backwardsMulti : 1;
+    movement = (right * directionalInput.x * strafeMulti * moveMulti) + (forward * forwardMovement * moveMulti);
+
+    if (player->getCollided() <= 0 || onIce) {
+        movement *= (airMulti * dt);
+        movement += rb->getLinearVelocity();
+    }
+};
+
+
+void PlayerController::HandleJumping() {
+    if (controller->GetDigital(Controller::DigitalControl::Jump) && player->getCollided() && inAirTime <= 0) {
+        audioEngine.PlaySounds("jump.wav", camera->GetPosition(), 0.0f);
+        btVector3 normal = FindFloorNormal();
+        float dotProduct = normal.dot(upDirection.absolute());
+        if (fabs(dotProduct <= 1)) {
+            movement += (jumpHeight * normal);
+        }
+        else {
+            movement += (jumpHeight * upDirection);
+        }
+        player->setCollided(0);
+        inAirTime = 0.2f;
+    }
+};
 
 
 void PlayerController::GetAllDirections() {

--- a/TeamProject/PlayerController.h
+++ b/TeamProject/PlayerController.h
@@ -38,52 +38,26 @@ namespace NCL {
 			void SetThirdPerson(bool thirdPersonIn) {
 				thirdPerson = thirdPersonIn;
 			};
-			void setTargetWorldRotation(btVector3 worldRotationIn) {
-				if (rotationChanging) return;
-				oldWorldRotation = upDirection;
-				targetWorldRotation = worldRotationIn;
-				rotateTimer = 0.0f;
-				rotationChanging = true;
-			}
-
-			btVector3 getUpDirection() {
-				return upDirection;
-			}
-
-			btVector3 getRightDirection() {
-				return rightDirection;
-			}
-
-			btVector3 getForwardDirection() {
-				return forwardDirection;
-			}
 
 			float getYaw() {
 				return yaw;
 			}
-			btQuaternion getCamOffset() {
-				return camRotOffset;
-			}
 
 			void rollRight() {
-				Rotate(true, true);
+				player->Rotate(true, true,yaw);
 			}
 
 			void rollLeft() {
-				Rotate(false, true);
+				player->Rotate(false, true,yaw);
 			}
 
 			void pitchUp() {
-				Rotate(true, false);
+				player->Rotate(true, false,yaw);
 			}
 
 			void pitchDown() {
-				Rotate(false, false);
+				player->Rotate(false, false,yaw);
 			}
-
-			void CalculateDirections(float dt);
-			btVector3 CalculateRightDirection(btVector3 upDir);
-			btVector3 CalculateForwardDirection(btVector3 upDir, btVector3 rightDir);
 
 		private:
 
@@ -123,14 +97,11 @@ namespace NCL {
 			//Special Types Variables
 			float bouncePadHeight = 5000.0f;
 
-			btQuaternion camRotOffset = btQuaternion::getIdentity();
-			btQuaternion oldcamRotOffset = btQuaternion::getIdentity();
-			btQuaternion targetcamRotOffset = btQuaternion::getIdentity();
-			btVector3 targetWorldRotation = btVector3(0, 1, 0);
-			btVector3 oldWorldRotation = btVector3(0, 1, 0);
+
 			btVector3 upDirection;
 			btVector3 rightDirection;
 			btVector3 forwardDirection;
+			btQuaternion camRotOffset;
 			float rotateTimer = 0.0f;
 			bool rotationChanging = false;
 			bool thirdPerson = false;
@@ -182,10 +153,7 @@ namespace NCL {
 			void SetGunTransform();
 			void Shoot();
 			void ShootBullet(btQuaternion bulletRotation, btVector3 hitPoint);
-			void Rotate(bool positive, bool rolling);
-			btVector3 CalculateUpDirection(float dt);
-			btVector3 CalculateForwardFromYaw();
-			btVector3 CalculateRightFromYaw();
+			void GetAllDirections();
 
 			// decal system
 			DecalSystem* decalSystem;

--- a/TeamProject/PlayerController.h
+++ b/TeamProject/PlayerController.h
@@ -141,19 +141,29 @@ namespace NCL {
 			bool onIce = false;
 			btVector3 previousVelocity;
 			std::shared_ptr<NCL::Rendering::Texture> pngTexture = nullptr;
+			btVector3 forward;
+			btVector3 up;
+			btVector3 right;
+			btVector3 movement;
 
 			Vector2 getDirectionalInput() const;
 			void Initialise();
 			void HandleShooting(float dt);
 			void HandleCrouching(float dt);
 			void HandleSliding(float dt);
-			void HandleTypes();
+			void SpecialTypeCalculations();
 			bool CheckCeling();
 			btVector3 FindFloorNormal();
 			void SetGunTransform();
 			void Shoot();
 			void ShootBullet(btQuaternion bulletRotation, btVector3 hitPoint);
 			void GetAllDirections();
+			void HandleYaw();
+			void RotationCalculations();
+			void CameraMovement();
+			void GroundNormalCalculations();
+			void MovementCalculations(float dt);
+			void HandleJumping();
 
 			// decal system
 			DecalSystem* decalSystem;

--- a/TeamProject/PlayerObject.cpp
+++ b/TeamProject/PlayerObject.cpp
@@ -2,3 +2,181 @@
 
 using namespace NCL;
 using namespace CSC8503;
+
+void PlayerObject::Update(float dt) {
+    upDirection = CalculateUpDirection(dt);
+    rightDirection = CalculateRightDirection(upDirection);
+    forwardDirection = CalculateForwardDirection(upDirection, rightDirection);
+}
+
+void PlayerObject::OnCollisionEnter(const CollisionInfo& collisionInfo){
+	if (collisionInfo.otherObject->getIsPaintball()) return;
+	btVector3 playerPos = this->GetPhysicsObject()->GetRigidBody()->getWorldTransform().getOrigin();
+	btVector3 objPos = collisionInfo.contactPointA;
+	btVector3 direction = (objPos - playerPos).normalized();
+	float dot = direction.dot(-upDirection);
+	float angle = acos(dot) * (180.0f / SIMD_PI);
+	if (angle <= 25.0f) {
+		collided++;
+		collidedObjects.push_back(collisionInfo.otherObject);
+	}
+
+	// set special type collision
+	collisionType = collisionInfo.otherObject->getType();
+	if (collisionInfo.otherObject->getType() == 'J' || collisionInfo.otherObject->getType() == 'S') {
+		collisionNormal = collisionInfo.contactNormal;
+		collisionPoint = collisionInfo.contactPointA;
+	}
+}
+
+void PlayerObject::OnCollisionExit(const CollisionInfo& collisionInfo){
+	if (collisionInfo.otherObject->getIsPaintball()) return;
+	auto it = std::find(collidedObjects.begin(), collidedObjects.end(), collisionInfo.otherObject);
+	if (it != collidedObjects.end()) {
+		collidedObjects.erase(it);
+		if (collided > 0) {
+			collided--;
+		}
+	}
+}
+
+void PlayerObject::OnCollisionStay(const CollisionInfo& collision){
+	if (collision.otherObject->getIsPaintball()) return;
+	btVector3 playerPos = this->GetPhysicsObject()->GetRigidBody()->getWorldTransform().getOrigin();
+	btVector3 objPos = collision.contactPointA;
+	btVector3 direction = (objPos - playerPos).normalized();
+	float dot = direction.dot(-upDirection);
+	float angle = acos(dot) * (180.0f / SIMD_PI);
+	auto it = std::find(collidedObjects.begin(), collidedObjects.end(), collision.otherObject);
+	if (it != collidedObjects.end()) { // contains already
+		if (angle > 25.0f) { // now too steep for floor
+			collidedObjects.erase(it);
+			if (collided > 0) {
+				collided--;
+			}
+		}
+	}
+	else { // not counted as floor yet
+		if (angle <= 25.0f) {
+			collided++;
+			collidedObjects.push_back(collision.otherObject);
+		}
+	}
+	// set special type collision
+	collisionType = collision.otherObject->getType();
+	if (collision.otherObject->getType() == 'J' || collision.otherObject->getType() == 'S') {
+		collisionNormal = collision.contactNormal;
+		collisionPoint = collision.contactPointA;
+	}
+}
+
+void PlayerObject::updateGravity(float dt) {
+	btVector3 movement = this->GetPhysicsObject()->GetRigidBody()->getLinearVelocity();
+	movement += upDirection * -(gravityScale * dt);
+	this->GetPhysicsObject()->GetRigidBody()->setLinearVelocity(movement);
+}
+
+// world rotate things
+void PlayerObject::Rotate(bool positive, bool rolling, float yaw) {
+    if (rotationChanging) return;
+    btVector3 rightDirections = (rolling ? CalculateForwardFromYaw(yaw) : CalculateRightFromYaw(yaw));
+    btQuaternion pitchQuat(rightDirections, Maths::DegreesToRadians(positive ? 90 : -90));
+    targetWorldRotation = quatRotate(pitchQuat, upDirection);
+    targetcamRotOffset = pitchQuat * oldcamRotOffset; // Apply rotation correctly
+    rotationChanging = true;
+}
+
+
+btVector3 PlayerObject::CalculateUpDirection(float dt) {
+    btVector3 upDir;
+    if (!rotationChanging) {
+        upDir = targetWorldRotation;
+        camRotOffset = targetcamRotOffset;
+
+    }
+    else if (rotateTimer <= rotateTime && rotationChanging) {
+        rotateTimer += dt;
+        upDir = lerp(oldWorldRotation, targetWorldRotation, rotateTimer / rotateTime);
+        camRotOffset = (oldcamRotOffset.slerp(targetcamRotOffset, rotateTimer / rotateTime));
+    }
+    else {
+        upDir = targetWorldRotation;
+        camRotOffset = targetcamRotOffset;
+        oldcamRotOffset = targetcamRotOffset;
+        oldWorldRotation = targetWorldRotation;
+        rotationChanging = false;
+        rotateTimer = 0.0f;
+    }
+    upDir.normalize();
+    return upDir;
+}
+
+
+//Most things past here are basically just helper functions
+btVector3 PlayerObject::CalculateForwardFromYaw(float yaw) {
+    int snappedYaw = static_cast<int>((yaw + 45) / 90) * 90 % 360;
+    btVector3 forwd = btVector3(0, 0, 0);
+    switch (snappedYaw) {
+    case 0: {
+        forwd = btVector3(0, 0, 1);
+        break;
+    }
+    case 90: {
+        forwd = btVector3(1, 0, 0);
+        break;
+    }
+    case 180: {
+        forwd = btVector3(0, 0, -1);
+        break;
+    }
+    case 270: {
+        forwd = btVector3(-1, 0, 0);
+        break;
+    }
+    }
+    btVector3 baseForward = quatRotate(oldcamRotOffset, forwd);
+    return baseForward;
+}
+
+btVector3 PlayerObject::CalculateRightFromYaw(float yaw) {
+    int snappedYaw = static_cast<int>((yaw + 45) / 90) * 90 % 360;
+    btVector3 right = btVector3(0, 0, 0);
+    switch (snappedYaw) {
+    case 0: {
+        right = btVector3(1, 0, 0);
+        break;
+    }
+    case 90: {
+        right = btVector3(0, 0, -1);
+        break;
+    }
+    case 180: {
+        right = btVector3(-1, 0, 0);
+        break;
+    }
+    case 270: {
+        right = btVector3(0, 0, 1);
+        break;
+    }
+    }
+    btVector3 baseForward = quatRotate(oldcamRotOffset, right);
+    return baseForward;
+}
+
+btVector3 PlayerObject::CalculateRightDirection(btVector3 upDir) {
+    btVector3 forward = btVector3(0, 0, 1);
+    if (fabs(upDir.dot(forward)) > 0.999f) {
+        forward = btVector3(0, 1, 0);
+    }
+    btVector3 rightDirection = upDir.cross(forward);
+    rightDirection.normalize();
+    return rightDirection;
+}
+
+btVector3 PlayerObject::CalculateForwardDirection(btVector3 upDir, btVector3 rightDir) {
+    btVector3 forwardDirection = rightDir.cross(upDir);
+    forwardDirection.normalize();
+    return forwardDirection;
+}
+
+

--- a/TeamProject/PlayerObject.cpp
+++ b/TeamProject/PlayerObject.cpp
@@ -70,11 +70,13 @@ void PlayerObject::OnCollisionStay(const CollisionInfo& collision){
 	}
 }
 
+
 void PlayerObject::updateGravity(float dt) {
 	btVector3 movement = this->GetPhysicsObject()->GetRigidBody()->getLinearVelocity();
 	movement += upDirection * -(gravityScale * dt);
 	this->GetPhysicsObject()->GetRigidBody()->setLinearVelocity(movement);
 }
+
 
 // world rotate things
 void PlayerObject::Rotate(bool positive, bool rolling, float yaw) {

--- a/TeamProject/PlayerObject.cpp
+++ b/TeamProject/PlayerObject.cpp
@@ -1,0 +1,4 @@
+#include "PlayerObject.h"
+
+using namespace NCL;
+using namespace CSC8503;

--- a/TeamProject/PlayerObject.h
+++ b/TeamProject/PlayerObject.h
@@ -35,6 +35,12 @@ public:
 		return upDirection;
 	}
 
+	void setUpDirection(btVector3 target) {
+		upDirection = target;
+		targetWorldRotation = target;
+		oldWorldRotation = target;
+	}
+
 	btVector3 getRightDirection() {
 		return rightDirection;
 	}

--- a/TeamProject/PlayerObject.h
+++ b/TeamProject/PlayerObject.h
@@ -21,72 +21,30 @@ enum class PlayerState {
 // Player class derived from GameObject
 class PlayerObject : public GameObject {
 public:
-	void OnCollisionEnter(const CollisionInfo& collisionInfo) override {
-		if (collisionInfo.otherObject->getIsPaintball()) return;
-		btVector3 playerPos = this->GetPhysicsObject()->GetRigidBody()->getWorldTransform().getOrigin();
-		btVector3 objPos = collisionInfo.contactPointA;
-		btVector3 direction = (objPos - playerPos).normalized();
-		float dot = direction.dot(-upDirection);
-		float angle = acos(dot) * (180.0f / SIMD_PI);
-		if (angle <= 25.0f) {
-			collided++;
-			collidedObjects.push_back(collisionInfo.otherObject);
-		}
+	void Update(float dt) override;
 
-		// set special type collision
-		collisionType = collisionInfo.otherObject->getType();
-		if (collisionInfo.otherObject->getType() == 'J' || collisionInfo.otherObject->getType() == 'S') {
-			collisionNormal = collisionInfo.contactNormal;
-			collisionPoint = collisionInfo.contactPointA;
-		}
+	void OnCollisionEnter(const CollisionInfo& collisionInfo) override;
+
+	void OnCollisionExit(const CollisionInfo& collisionInfo) override;
+
+	void OnCollisionStay(const CollisionInfo& collision) override;
+
+	void updateGravity(float dt);
+
+	btVector3 getUpDirection() {
+		return upDirection;
 	}
 
-
-	void OnCollisionExit(const CollisionInfo& collisionInfo) override {
-		if (collisionInfo.otherObject->getIsPaintball()) return;
-		auto it = std::find(collidedObjects.begin(), collidedObjects.end(), collisionInfo.otherObject);
-		if (it != collidedObjects.end()) {
-			collidedObjects.erase(it);
-			if (collided > 0) {
-				collided--;
-			}
-		}
+	btVector3 getRightDirection() {
+		return rightDirection;
 	}
 
-	void OnCollisionStay(const CollisionInfo& collision) override {
-		if (collision.otherObject->getIsPaintball()) return;
-		btVector3 playerPos = this->GetPhysicsObject()->GetRigidBody()->getWorldTransform().getOrigin();
-		btVector3 objPos = collision.contactPointA;
-		btVector3 direction = (objPos - playerPos).normalized();
-		float dot = direction.dot(-upDirection);
-		float angle = acos(dot) * (180.0f / SIMD_PI);
-		auto it = std::find(collidedObjects.begin(), collidedObjects.end(), collision.otherObject);
-		if (it != collidedObjects.end()) { // contains already
-			if (angle > 25.0f) { // now too steep for floor
-				collidedObjects.erase(it);
-				if (collided > 0) {
-					collided--;
-				}
-			}
-		}
-		else { // not counted as floor yet
-			if (angle <= 25.0f) {
-				collided++;
-				collidedObjects.push_back(collision.otherObject);
-			}
-		}
-		// set special type collision
-		collisionType = collision.otherObject->getType();
-		if (collision.otherObject->getType() == 'J' || collision.otherObject->getType() == 'S') {
-			collisionNormal = collision.contactNormal;
-			collisionPoint = collision.contactPointA;
-		}
+	btVector3 getForwardDirection() {
+		return forwardDirection;
 	}
 
-	void updateGravity(float dt) {
-		btVector3 movement = this->GetPhysicsObject()->GetRigidBody()->getLinearVelocity();
-		movement += upDirection * -(gravityScale * dt);
-		this->GetPhysicsObject()->GetRigidBody()->setLinearVelocity(movement);
+	btQuaternion getCamOffset() {
+		return camRotOffset;
 	}
 
 	char getType() {
@@ -101,15 +59,14 @@ public:
 	int getCollided() {
 		return collided;
 	}
-	void setUpDirection(btVector3 upDirectionIn) {
-		upDirection = upDirectionIn;
-	};
+
 	btVector3 getCollisionNormal() {
 		return collisionNormal;
 	}
 	btVector3 getCollisionPoint() {
 		return collisionPoint;
 	}
+	void Rotate(bool positive, bool rolling, float yaw);
 
 	/**
 	 * @brief Get the state of the player (usually alive or dead).
@@ -118,13 +75,36 @@ public:
 	inline PlayerState GetState() { return state; }
 
 private:
+
+
+
+	//Player Variables
 	float gravityScale = 400.0f;
+	float rotateTime = 0.5f;
 
 	int collided = 0;
-	btVector3 upDirection;
 	btVector3 collisionNormal = btVector3(0, 1, 0);
 	btVector3 collisionPoint = btVector3(0, 0, 0);
 	std::list<GameObject*> collidedObjects;
 	char collisionType;
 	PlayerState state;
+
+	btQuaternion camRotOffset = btQuaternion::getIdentity();
+	btQuaternion oldcamRotOffset = btQuaternion::getIdentity();
+	btQuaternion targetcamRotOffset = btQuaternion::getIdentity();
+	btVector3 targetWorldRotation = btVector3(0, 1, 0);
+	btVector3 oldWorldRotation = btVector3(0, 1, 0);
+	btVector3 upDirection;
+	btVector3 rightDirection;
+	btVector3 forwardDirection;
+	float rotateTimer = 0.0f;
+	bool rotationChanging = false;
+
+	void CalculateDirections(float dt);
+	btVector3 CalculateRightDirection(btVector3 upDir);
+	btVector3 CalculateForwardDirection(btVector3 upDir, btVector3 rightDir);
+	btVector3 CalculateUpDirection(float dt);
+	btVector3 CalculateForwardFromYaw(float yaw);
+	btVector3 CalculateRightFromYaw(float yaw);
+
 };

--- a/TeamProject/PlayerObject.h
+++ b/TeamProject/PlayerObject.h
@@ -7,7 +7,6 @@
 #include "PhysicsObject.h"
 #include "CollisionInfo.h"
 
-
 #include <btBulletDynamicsCommon.h>
 #include <btBulletCollisionCommon.h>
 
@@ -53,6 +52,8 @@ public:
 		return camRotOffset;
 	}
 
+	void Rotate(bool positive, bool rolling, float yaw);
+
 	char getType() {
 		return collisionType;
 	}
@@ -72,7 +73,6 @@ public:
 	btVector3 getCollisionPoint() {
 		return collisionPoint;
 	}
-	void Rotate(bool positive, bool rolling, float yaw);
 
 	/**
 	 * @brief Get the state of the player (usually alive or dead).
@@ -81,8 +81,6 @@ public:
 	inline PlayerState GetState() { return state; }
 
 private:
-
-
 
 	//Player Variables
 	float gravityScale = 400.0f;
@@ -106,7 +104,6 @@ private:
 	float rotateTimer = 0.0f;
 	bool rotationChanging = false;
 
-	void CalculateDirections(float dt);
 	btVector3 CalculateRightDirection(btVector3 upDir);
 	btVector3 CalculateForwardDirection(btVector3 upDir, btVector3 rightDir);
 	btVector3 CalculateUpDirection(float dt);

--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -121,7 +121,6 @@ void TutorialGame::UpdateGame(float dt) {
 
 void TutorialGame::UpdatePlayer(float dt) {
 
-	playerController->CalculateDirections(dt);
 	// Press F for freeCam, press G for thirdPerson
 	if (freeCam) {
 		//freeCam Movement
@@ -188,7 +187,7 @@ void TutorialGame::UpdateKeys() {
 void TutorialGame::ThirdPersonControls() {
 	btTransform transformPlayer = player->GetPhysicsObject()->GetRigidBody()->getWorldTransform();
 	btQuaternion playerRotation1(btVector3(0, 1, 0), Maths::DegreesToRadians(playerController->getYaw()));
-	btMatrix3x3 rotationMatrix(playerController->getCamOffset() * playerRotation1);
+	btMatrix3x3 rotationMatrix(player->getCamOffset() * playerRotation1);
 	btVector3 forward = rotationMatrix * btVector3(0,0,-1);
 	btVector3 upwards = rotationMatrix * btVector3(0, 1, 0);
 	float camHeight = 10.0f;


### PR DESCRIPTION
UpDirection calculations are now all stored and handled in playerObject rather than playerController. 
Changing the upDirection requires either an input from the controller with the yaw, or you can manually set the upDirection for networked clients as this will be send across in the packets.