### PR TITLE
Don't disable deactivation of physics objects

### DIFF
--- a/CSC8503CoreClasses/PhysicsObject.cpp
+++ b/CSC8503CoreClasses/PhysicsObject.cpp
@@ -45,7 +45,6 @@ void PhysicsObject::InitBulletPhysics(btDynamicsWorld* world, btCollisionShape* 
 	// Setting the object's properties
 	rigidBody->setMassProps(mass, localInertia);
 	rigidBody->setUserPointer(parent);
-	rigidBody->setActivationState(DISABLE_DEACTIVATION);
 
 	if (collide) {
 		world->addRigidBody(rigidBody);


### PR DESCRIPTION
Bullet automatically reactivates when another object collides, saves ~20% on physics update