### PR TITLE
Edge detection

### DIFF
--- a/Assets/Shaders/edgedetectfrag.glsl
+++ b/Assets/Shaders/edgedetectfrag.glsl
@@ -1,9 +1,24 @@
 #version 330 core
 
 uniform sampler2D sceneTex;
-//uniform sampler2D depthTex;
+uniform sampler2D depthTex;
 
 uniform vec2 windowSize;
+
+// uniform float nearPlane;  //This section is as in decal.frag
+// uniform float farPlane;
+const float nearPlane = 0.1;
+const float farPlane = 100.0;
+
+// Function to convert non-linear depth values to linear depth values
+// https://learnopengl.com/Advanced-OpenGL/Depth-testing
+float LinearizeDepth(float depth) {
+    return (2.0 * nearPlane) / (farPlane + nearPlane - depth * (farPlane - nearPlane));
+}
+
+//idea, sample depthTex, linearise these values then apply edge detection kernal to detect where edges exist in depth buffer. Then sample the colour texture and apply the 
+//black outlines where there are edges in the depth buffer. Maybe use gl_FragCoord?
+
 
 in Vertex {
     vec2 texCoord;
@@ -14,12 +29,12 @@ out vec4 fragColor;
 //could maybe use windowsize like in vignettefrag for offsets instead
 /*const*/ float offset_x = 1/windowSize.x; //do these have to be const floats?
 /*const*/ float offset_y = 1/windowSize.y; //(number of pixels in y axis)
-/*
+
 float kernel[9] = float[] ( //defines weightings of each pixel. Should add up to 1. If less than 1, scene darkens and if greater than 1 it brightens.
-      1,  1, 1,             //here, they add up to zero to darken everything besides the edges which will be highlighted
-      1, -8, 1,             //BLACKBOARDISH effect
-      1,  1, 1
-);*/
+      -1,  -1,  -1,             //here, they add up to zero to darken everything besides the edges which will be highlighted
+      -1,   9,  -1,             //BLACKBOARDISH effect
+      -1,  -1,  -1
+);
 
 /*float kernel[9] = float[] (
        0, -1,  0,
@@ -38,12 +53,12 @@ float kernel[9] = float[] ( //defines weightings of each pixel. Should add up to
       -1,  1, 1,
        0,  1, 2
        );*/
-
+/*
 float kernel[9] = float[] (
-     -1/18, -1/18, -1/18, 
-     -1/18,  5/2, -1/18,
-     -1/18, -1/18, -1/18
-     );
+      -1, 0, 1,
+      -2, 1, 2, 
+      -1, 0, 1
+     );*/
 //other kernels to try:  0, -1,  0      1/9, 1/9, 1/9,    -2, -1, 0,
 //                      -1,  5, -1      1/9, 1/9, 1/9,    -1,  1, 1,
 //                       0, -1,  0      1/9, 1/9, 1/9      0,  1, 2
@@ -53,9 +68,24 @@ vec2 offsets[9] = vec2[] (
       vec2(-offset_x, -offset_y), vec2(0.0f, -offset_y), vec2(offset_x, -offset_y)
       ); 
 
-void main(void) {
+void main(void) {//for edge detection kernels, the resulting value for a pixel is high at edges (rapid value changes)
+     float SceneDepthNonLinear = texture(depthTex, IN.texCoord).r; //attempting to use the depth buffer to find edges instead of colour attachment
+     float fragDepth = LinearizeDepth(SceneDepthNonLinear);
+
      vec3 colour = vec3(0.0f);
-     for (int i = 0; i < 9; i++) //idk why no brackets here
-         colour += vec3(texture(sceneTex, IN.texCoord.st+offsets[i]))* kernel[i];
+     vec3 tempCol = vec3(0.0f);
+     colour = texture(sceneTex, IN.texCoord).rgb; //initially just render scene as is ////////
+     for (int i = 0; i < 9; i++) {//idk why no brackets here
+        /*if (vec3(texture(sceneTex, IN.texCoord.st+offsets[i])) * kernel[i]) > vec3(1.0f)) {
+            colour = vec3(0, 0, 0);
+            }*/
+            tempCol += vec3(texture(depthTex, IN.texCoord.st+offsets[i])) * kernel[i]; //in theory this value should be large at edges only. This is the convolution.
+     }
+       if (length(tempCol) > 1) {//seemingly this needs to be exactly 1 to work with the current kernel 
+                colour = vec3(0, 0, 0);
+                }
+         //colour += vec3(texture(depthTex, IN.texCoord.st+offsets[i]))* kernel[i]; //previously sampled the sceneTex
      fragColor = vec4(colour, 1.0f);
      }
+
+     //using the offsets we can sample what would be the neighbouring pixel values seeing as these colour values are currently stored in a texture anyways

--- a/Assets/Shaders/edgedetectfrag.glsl
+++ b/Assets/Shaders/edgedetectfrag.glsl
@@ -51,18 +51,21 @@ vec3 calculateNormal(vec2 texCoord){
 }
 
 
-float thickness = 1.0f;
-vec2 offsets[9] = vec2[] (
-    vec2(-thickness * offset_x,  thickness * offset_y), vec2(0.0,  thickness * offset_y), vec2(thickness * offset_x,  thickness * offset_y),
-    vec2(-thickness * offset_x,  0.0),            vec2(0.0,  0.0),            vec2(thickness * offset_x,  0.0),
-    vec2(-thickness * offset_x, -thickness * offset_y), vec2(0.0, -thickness * offset_y), vec2(thickness * offset_x, -thickness * offset_y)
+
+vec2 offsets[25] = vec2[] (
+    vec2(-2.0 * offset_x,  2.0 * offset_y), vec2(-offset_x,  2.0 * offset_y), vec2(0.0,  2.0 * offset_y), vec2(offset_x,  2.0 * offset_y), vec2(2.0 * offset_x,  2.0 * offset_y),
+    vec2(-2.0 * offset_x,  offset_y),      vec2(-offset_x,  offset_y),      vec2(0.0,  offset_y),      vec2(offset_x,  offset_y),      vec2(2.0 * offset_x,  offset_y),
+    vec2(-2.0 * offset_x,  0.0),           vec2(-offset_x,  0.0),           vec2(0.0,  0.0),           vec2(offset_x,  0.0),           vec2(2.0 * offset_x,  0.0),
+    vec2(-2.0 * offset_x, -offset_y),      vec2(-offset_x, -offset_y),      vec2(0.0, -offset_y),      vec2(offset_x, -offset_y),      vec2(2.0 * offset_x, -offset_y),
+    vec2(-2.0 * offset_x, -2.0 * offset_y), vec2(-offset_x, -2.0 * offset_y), vec2(0.0, -2.0 * offset_y), vec2(offset_x, -2.0 * offset_y), vec2(2.0 * offset_x, -2.0 * offset_y)
 );
+
 
 
 void main(void) {
    vec4 colour = texture(sceneTex, IN.texCoord); //initially just render scene as is ////////
    vec3 normalWorld = calculateNormal(IN.texCoord);
-   for (int i = 0; i < 9; i++) {
+   for (int i = 0; i < 25; i++) {
        vec3 normalWorld2 =calculateNormal(IN.texCoord+offsets[i]); // check surrounding normals
        if(distance(normalWorld,normalWorld2) > 0.9f){ // normals are substantially different
            colour = vec4(0,0,0,1);

--- a/Assets/Shaders/edgedetectfrag.glsl
+++ b/Assets/Shaders/edgedetectfrag.glsl
@@ -1,0 +1,37 @@
+#version 330 core
+
+uniform sampler2D sceneTex;
+
+uniform vec2 windowSize;
+
+in Vertex {
+    vec2 texCoord;
+    } IN;
+
+out vec4 fragColor;
+
+//could maybe use windowsize like in vignettefrag for offsets instead
+/*const*/ float offset_x = 1/windowSize.x; //do these have to be const floats?
+/*const*/ float offset_y = 1/windowSize.y; //(number of pixels in y axis)
+
+float kernel[9] = float[] ( //defines weightings of each pixel. Should add up to 1. If less than 1, scene darkens and if greater than 1 it brightens.
+      1,  1, 1,             //here, they add up to zero to darken everything besides the edges which will be highlighted
+      1, -8, 1,
+      1,  1, 1
+);
+
+//other kernels to try:  0, -1,  0      1/9, 1/9, 1/9,    -2, -1, 0,
+//                      -1,  5, -1      1/9, 1/9, 1/9,    -1,  1, 1,
+//                       0, -1,  0      1/9, 1/9, 1/9      0,  1, 2
+vec2 offsets[9] = vec2[] ( 
+      vec2(-offset_x, offset_y),  vec2(0.0f, offset_y),  vec2(offset_x, offset_y), 
+      vec2(-offset_x, 0.0f),      vec2(0.0f, 0.0f),      vec2(offset_x, 0.0f),
+      vec2(-offset_x, -offset_y), vec2(0.0f, -offset_y), vec2(offset_x, -offset_y)
+      ); 
+
+void main(void) {
+     vec3 colour = vec3(0.0f);
+     for (int i = 0; i < 9; i++) //idk why no brackets here
+         colour += vec3(texture(sceneTex, IN.texCoord.st+offsets[i]))* kernel[i];
+     fragColor = vec4(colour, 1.0f);
+     }

--- a/Assets/Shaders/edgedetectfrag.glsl
+++ b/Assets/Shaders/edgedetectfrag.glsl
@@ -67,7 +67,7 @@ void main(void) {
    vec3 normalWorld = calculateNormal(IN.texCoord);
    for (int i = 0; i < 25; i++) {
        vec3 normalWorld2 =calculateNormal(IN.texCoord+offsets[i]); // check surrounding normals
-       if(distance(normalWorld,normalWorld2) > 0.9f){ // normals are substantially different
+       if(distance(normalWorld,normalWorld2) > 0.75f){ // normals are substantially different
            colour = vec4(0,0,0,1);
            break;
         }

--- a/Assets/Shaders/edgedetectfrag.glsl
+++ b/Assets/Shaders/edgedetectfrag.glsl
@@ -1,6 +1,7 @@
 #version 330 core
 
 uniform sampler2D sceneTex;
+//uniform sampler2D depthTex;
 
 uniform vec2 windowSize;
 
@@ -13,18 +14,41 @@ out vec4 fragColor;
 //could maybe use windowsize like in vignettefrag for offsets instead
 /*const*/ float offset_x = 1/windowSize.x; //do these have to be const floats?
 /*const*/ float offset_y = 1/windowSize.y; //(number of pixels in y axis)
-
+/*
 float kernel[9] = float[] ( //defines weightings of each pixel. Should add up to 1. If less than 1, scene darkens and if greater than 1 it brightens.
       1,  1, 1,             //here, they add up to zero to darken everything besides the edges which will be highlighted
-      1, -8, 1,
+      1, -8, 1,             //BLACKBOARDISH effect
       1,  1, 1
-);
+);*/
 
+/*float kernel[9] = float[] (
+       0, -1,  0,
+      -1,  5, -1,
+       0,  -1, 0
+       );*/
+
+/*float kernel[9] = float[] ( //this one looks too dark/doesn't render anything
+      1/9, 1/9, 1/9,
+      1/9, 1/9, 1/9,
+      1/9, 1/9, 1/9
+      );*/
+
+/*float kernel[9] = float[] (
+      -2, -1, 0, 
+      -1,  1, 1,
+       0,  1, 2
+       );*/
+
+float kernel[9] = float[] (
+     -1/18, -1/18, -1/18, 
+     -1/18,  5/2, -1/18,
+     -1/18, -1/18, -1/18
+     );
 //other kernels to try:  0, -1,  0      1/9, 1/9, 1/9,    -2, -1, 0,
 //                      -1,  5, -1      1/9, 1/9, 1/9,    -1,  1, 1,
 //                       0, -1,  0      1/9, 1/9, 1/9      0,  1, 2
 vec2 offsets[9] = vec2[] ( 
-      vec2(-offset_x, offset_y),  vec2(0.0f, offset_y),  vec2(offset_x, offset_y), 
+      vec2(-offset_x, offset_y),  vec2(0.0f, offset_y),  vec2(offset_x, offset_y), //each value is the offset in pixels from the centre pixel
       vec2(-offset_x, 0.0f),      vec2(0.0f, 0.0f),      vec2(offset_x, 0.0f),
       vec2(-offset_x, -offset_y), vec2(0.0f, -offset_y), vec2(offset_x, -offset_y)
       ); 

--- a/Assets/Shaders/edgedetectfrag.glsl
+++ b/Assets/Shaders/edgedetectfrag.glsl
@@ -4,88 +4,71 @@ uniform sampler2D sceneTex;
 uniform sampler2D depthTex;
 
 uniform vec2 windowSize;
+uniform float nearPlane;
+uniform float farPlane;
 
-// uniform float nearPlane;  //This section is as in decal.frag
-// uniform float farPlane;
-const float nearPlane = 0.1;
-const float farPlane = 100.0;
-
-// Function to convert non-linear depth values to linear depth values
-// https://learnopengl.com/Advanced-OpenGL/Depth-testing
-float LinearizeDepth(float depth) {
-    return (2.0 * nearPlane) / (farPlane + nearPlane - depth * (farPlane - nearPlane));
-}
-
-//idea, sample depthTex, linearise these values then apply edge detection kernal to detect where edges exist in depth buffer. Then sample the colour texture and apply the 
-//black outlines where there are edges in the depth buffer. Maybe use gl_FragCoord?
+uniform mat4 inverseProjMatrix;
+uniform mat4 inverseViewMatrix;
 
 
 in Vertex {
     vec2 texCoord;
-    } IN;
+} IN;
 
 out vec4 fragColor;
 
 //could maybe use windowsize like in vignettefrag for offsets instead
-/*const*/ float offset_x = 1/windowSize.x; //do these have to be const floats?
-/*const*/ float offset_y = 1/windowSize.y; //(number of pixels in y axis)
+float offset_x = 1/windowSize.x; //do these have to be const floats?
+float offset_y = 1/windowSize.y; //(number of pixels in y axis)
 
-float kernel[9] = float[] ( //defines weightings of each pixel. Should add up to 1. If less than 1, scene darkens and if greater than 1 it brightens.
-      -1,  -1,  -1,             //here, they add up to zero to darken everything besides the edges which will be highlighted
-      -1,   9,  -1,             //BLACKBOARDISH effect
-      -1,  -1,  -1
+
+vec3 DepthToWorldPosition(vec2 texCoords, float depth) {
+    // Convert texture coordinates to (-1 to 1 range)
+    vec4 ndc = vec4(texCoords * 2.0 - 1.0, depth * 2.0 - 1.0, 1.0);
+    // Transform to view space
+    vec4 viewPos = inverseProjMatrix * ndc;
+    viewPos /= viewPos.w;
+    // Transform to world space
+    vec4 worldPos = inverseViewMatrix * viewPos;
+    return worldPos.xyz;
+}
+
+
+vec3 calculateNormal(vec2 texCoord){
+    //sample centre and offsets
+    float depthCenter = texture(depthTex, texCoord).r;
+    float depthRight = texture(depthTex, texCoord + vec2(offset_x, 0)).r;
+    float depthUp = texture(depthTex, texCoord + vec2(0, offset_y)).r;
+
+    //convert to world space
+    vec3 P = DepthToWorldPosition(texCoord, depthCenter);
+    vec3 Pr = DepthToWorldPosition(texCoord + vec2(offset_x, 0), depthRight);
+    vec3 Pu = DepthToWorldPosition(texCoord + vec2(0, offset_y), depthUp);
+
+    // Compute normal using cross product of tangent vectors
+    vec3 normalWorld = normalize(cross(Pr - P, Pu - P));
+    return normalWorld;
+}
+
+
+float thickness = 1.0f;
+vec2 offsets[9] = vec2[] (
+    vec2(-thickness * offset_x,  thickness * offset_y), vec2(0.0,  thickness * offset_y), vec2(thickness * offset_x,  thickness * offset_y),
+    vec2(-thickness * offset_x,  0.0),            vec2(0.0,  0.0),            vec2(thickness * offset_x,  0.0),
+    vec2(-thickness * offset_x, -thickness * offset_y), vec2(0.0, -thickness * offset_y), vec2(thickness * offset_x, -thickness * offset_y)
 );
 
-/*float kernel[9] = float[] (
-       0, -1,  0,
-      -1,  5, -1,
-       0,  -1, 0
-       );*/
 
-/*float kernel[9] = float[] ( //this one looks too dark/doesn't render anything
-      1/9, 1/9, 1/9,
-      1/9, 1/9, 1/9,
-      1/9, 1/9, 1/9
-      );*/
+void main(void) {
+   vec4 colour = texture(sceneTex, IN.texCoord); //initially just render scene as is ////////
+   vec3 normalWorld = calculateNormal(IN.texCoord);
+   for (int i = 0; i < 9; i++) {
+       vec3 normalWorld2 =calculateNormal(IN.texCoord+offsets[i]); // check surrounding normals
+       if(distance(normalWorld,normalWorld2) > 0.9f){ // normals are substantially different
+           colour = vec4(0,0,0,1);
+           break;
+        }
+    }
+   fragColor = colour;
 
-/*float kernel[9] = float[] (
-      -2, -1, 0, 
-      -1,  1, 1,
-       0,  1, 2
-       );*/
-/*
-float kernel[9] = float[] (
-      -1, 0, 1,
-      -2, 1, 2, 
-      -1, 0, 1
-     );*/
-//other kernels to try:  0, -1,  0      1/9, 1/9, 1/9,    -2, -1, 0,
-//                      -1,  5, -1      1/9, 1/9, 1/9,    -1,  1, 1,
-//                       0, -1,  0      1/9, 1/9, 1/9      0,  1, 2
-vec2 offsets[9] = vec2[] ( 
-      vec2(-offset_x, offset_y),  vec2(0.0f, offset_y),  vec2(offset_x, offset_y), //each value is the offset in pixels from the centre pixel
-      vec2(-offset_x, 0.0f),      vec2(0.0f, 0.0f),      vec2(offset_x, 0.0f),
-      vec2(-offset_x, -offset_y), vec2(0.0f, -offset_y), vec2(offset_x, -offset_y)
-      ); 
-
-void main(void) {//for edge detection kernels, the resulting value for a pixel is high at edges (rapid value changes)
-     float SceneDepthNonLinear = texture(depthTex, IN.texCoord).r; //attempting to use the depth buffer to find edges instead of colour attachment
-     float fragDepth = LinearizeDepth(SceneDepthNonLinear);
-
-     vec3 colour = vec3(0.0f);
-     vec3 tempCol = vec3(0.0f);
-     colour = texture(sceneTex, IN.texCoord).rgb; //initially just render scene as is ////////
-     for (int i = 0; i < 9; i++) {//idk why no brackets here
-        /*if (vec3(texture(sceneTex, IN.texCoord.st+offsets[i])) * kernel[i]) > vec3(1.0f)) {
-            colour = vec3(0, 0, 0);
-            }*/
-            tempCol += vec3(texture(depthTex, IN.texCoord.st+offsets[i])) * kernel[i]; //in theory this value should be large at edges only. This is the convolution.
-     }
-       if (length(tempCol) > 1) {//seemingly this needs to be exactly 1 to work with the current kernel 
-                colour = vec3(0, 0, 0);
-                }
-         //colour += vec3(texture(depthTex, IN.texCoord.st+offsets[i]))* kernel[i]; //previously sampled the sceneTex
-     fragColor = vec4(colour, 1.0f);
-     }
-
-     //using the offsets we can sample what would be the neighbouring pixel values seeing as these colour values are currently stored in a texture anyways
+ }

--- a/TeamProject/GameTechRenderer.cpp
+++ b/TeamProject/GameTechRenderer.cpp
@@ -840,6 +840,17 @@ void GameTechRenderer::RenderPostProcessing() { //gonna try putting edge detecti
 		glBindTexture(GL_TEXTURE_2D, bufferDepthTex);
 		glUniform1i(glGetUniformLocation(edgedetectShader->GetProgramID(), "depthTex"), 1);
 		glUniform2f(glGetUniformLocation(edgedetectShader->GetProgramID(), "windowSize"), windowSize.x, windowSize.y); 
+		glUniform1f(glGetUniformLocation(edgedetectShader->GetProgramID(), "nearPlane"), camera->GetNearPlane());
+		glUniform1f(glGetUniformLocation(edgedetectShader->GetProgramID(), "farPlane"), camera->GetFarPlane());
+		//using the same proj and view matrices from RenderCamera(): 
+		Matrix4 viewMatrix = camera->BuildViewMatrix();
+		Matrix4 projMatrix = camera->BuildProjectionMatrix(hostWindow->GetScreenAspect());
+		Matrix4 invProj = Matrix::Inverse(projMatrix); 
+		Matrix4 invView = Matrix::Inverse(viewMatrix);
+
+		glUniformMatrix4fv(glGetUniformLocation(edgedetectShader->GetProgramID(), "inverseProjMatrix"), 1, false, (float*)&invProj);
+		glUniformMatrix4fv(glGetUniformLocation(edgedetectShader->GetProgramID(), "inverseViewMatrix"), 1, false, (float*)&invView);
+
 		BindMesh(*fullscreenQuad);
 		DrawBoundMesh();
 	    //Vignette post processing:
@@ -860,6 +871,8 @@ void GameTechRenderer::RenderPostProcessing() { //gonna try putting edge detecti
 		glUniform1f(glGetUniformLocation(vignetteShader->GetProgramID(), "intensity"), vignetteIntensity);
 
 		glUniform1f(glGetUniformLocation(vignetteShader->GetProgramID(), "time"), vignettePulse);
+
+
 		BindMesh(*fullscreenQuad); //simply a quad   
 		DrawBoundMesh(); //finished rendering into BTex now, ready to unbind to draw quad straight to screen next:
 		//HDR post processing:

--- a/TeamProject/GameTechRenderer.cpp
+++ b/TeamProject/GameTechRenderer.cpp
@@ -827,20 +827,23 @@ void GameTechRenderer::RenderDecals() {
 
 void GameTechRenderer::RenderPostProcessing() { //gonna try putting edge detection first:
         //Edge detection:
-	    glBindFramebuffer(GL_FRAMEBUFFER, BFBO);
+	    glBindFramebuffer(GL_FRAMEBUFFER, hdrFBO);//was BFBO
 		glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 		glDisable(GL_CULL_FACE);
 		glDisable(GL_BLEND);
 		glDisable(GL_DEPTH_TEST);
 		UseShader(*edgedetectShader);
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, bufferColourTex); //currently holds the scene, gonna have to change up the vignette part to accomodate this
+		glBindTexture(GL_TEXTURE_2D, BTex); //currently holds the scene, gonna have to change up the vignette part to accomodate this //was bufferColourTex
 		glUniform1i(glGetUniformLocation(edgedetectShader->GetProgramID(), "sceneTex"), 0);
-		glUniform2f(glGetUniformLocation(edgedetectShader->GetProgramID(), "windowSize"), windowSize.x, windowSize.y);
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, bufferDepthTex);
+		glUniform1i(glGetUniformLocation(edgedetectShader->GetProgramID(), "depthTex"), 1);
+		glUniform2f(glGetUniformLocation(edgedetectShader->GetProgramID(), "windowSize"), windowSize.x, windowSize.y); 
 		BindMesh(*fullscreenQuad);
 		DrawBoundMesh();
 	    //Vignette post processing:
-	    glBindFramebuffer(GL_FRAMEBUFFER, hdrFBO); //unbind hdrFBO and set BFBO    //was BFBO before adding edge detection
+	    glBindFramebuffer(GL_FRAMEBUFFER, BFBO); //unbind hdrFBO and set BFBO    //was BFBO before adding edge detection //was hdrFBO
 	    glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	    glDisable(GL_CULL_FACE);
 	    glDisable(GL_BLEND);
@@ -848,7 +851,7 @@ void GameTechRenderer::RenderPostProcessing() { //gonna try putting edge detecti
 	    UseShader(*vignetteShader);
 	    glUniform1i(glGetUniformLocation(vignetteShader->GetProgramID(), "vignetteOn"), GetVignetteOn());
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, BTex); //hdrTex currently holds raw scene  //was bufferColourTex before adding edge detection
+		glBindTexture(GL_TEXTURE_2D, hdrTex); //hdrTex currently holds raw scene  //was bufferColourTex before adding edge detection //was BTex
 		glUniform1i(glGetUniformLocation(vignetteShader->GetProgramID(), "diffuseTex"), 0);
 		glUniform2f(glGetUniformLocation(vignetteShader->GetProgramID(), "windowSize"), windowSize.x, windowSize.y);
 		Vector3 VignetteColour = Vector3(0.0, 0.0, 0.0); //different colours appear more intense at a given intensity (green)
@@ -867,8 +870,8 @@ void GameTechRenderer::RenderPostProcessing() { //gonna try putting edge detecti
 		glDisable(GL_DEPTH_TEST);
 		UseShader(*hdrShader);
 		glUniform1i(glGetUniformLocation(hdrShader->GetProgramID(), "hdrOn"), GetHDROn()); //send bool to shader so it knows whether to output scene with or without post processing
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, hdrTex);//BTex holds vignetted processed scene (whether applied or not). (tonemapping should be done pretty much last) //was BTex before edge detection
+		glActiveTexture(GL_TEXTURE0); //was hdrTex
+		glBindTexture(GL_TEXTURE_2D, BTex);//BTex holds vignetted processed scene (whether applied or not). (tonemapping should be done pretty much last) //was BTex before edge detection
 		glUniform1i(glGetUniformLocation(hdrShader->GetProgramID(), "hdrTex"), 0);
 		BindMesh(*fullscreenQuad); //using unitQuad instead of fullscreen quad
 		DrawBoundMesh();
@@ -1021,7 +1024,7 @@ void GameTechRenderer::DrawPointLights() {
 }
 
 void GameTechRenderer::CombineBuffers() {//basically final post processing output. Don't need to update matrices as fullscreen quad is not transformed at all
-	glBindFramebuffer(GL_FRAMEBUFFER, bufferFBO); //swapped hdrFBO with bufferFBO to allow decals to work
+	glBindFramebuffer(GL_FRAMEBUFFER, BFBO); //swapped hdrFBO with bufferFBO to allow decals to work //was bufferFBO
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT); //without this line, output is just black 
 	UseShader(*combineShader); 
 	glUniform1i(glGetUniformLocation(combineShader->GetProgramID(), "diffuseTex"), 0);

--- a/TeamProject/GameTechRenderer.cpp
+++ b/TeamProject/GameTechRenderer.cpp
@@ -139,6 +139,7 @@ GameTechRenderer::GameTechRenderer(Window* window) : OGLRenderer(window), GameTe
 	fullscreenQuad->UploadToGPU(); 
 
 	vignetteShader = new OGLShader("texturevert.glsl", "vignettefrag.glsl");
+	edgedetectShader = new OGLShader("texturevert.glsl", "edgedetectfrag.glsl");
 
  	//start setting up framebuffers for post processing:
 	//first generate the textures to store the rendered scene:
@@ -824,9 +825,22 @@ void GameTechRenderer::RenderDecals() {
 	glDepthFunc(GL_LEQUAL);
 }
 
-void GameTechRenderer::RenderPostProcessing() {
-	//Vignette post processing:
-	    glBindFramebuffer(GL_FRAMEBUFFER, BFBO); //unbind hdrFBO and set BFBO   
+void GameTechRenderer::RenderPostProcessing() { //gonna try putting edge detection first:
+        //Edge detection:
+	    glBindFramebuffer(GL_FRAMEBUFFER, BFBO);
+		glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
+		glDisable(GL_CULL_FACE);
+		glDisable(GL_BLEND);
+		glDisable(GL_DEPTH_TEST);
+		UseShader(*edgedetectShader);
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, bufferColourTex); //currently holds the scene, gonna have to change up the vignette part to accomodate this
+		glUniform1i(glGetUniformLocation(edgedetectShader->GetProgramID(), "sceneTex"), 0);
+		glUniform2f(glGetUniformLocation(edgedetectShader->GetProgramID(), "windowSize"), windowSize.x, windowSize.y);
+		BindMesh(*fullscreenQuad);
+		DrawBoundMesh();
+	    //Vignette post processing:
+	    glBindFramebuffer(GL_FRAMEBUFFER, hdrFBO); //unbind hdrFBO and set BFBO    //was BFBO before adding edge detection
 	    glClear(GL_DEPTH_BUFFER_BIT | GL_COLOR_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 	    glDisable(GL_CULL_FACE);
 	    glDisable(GL_BLEND);
@@ -834,7 +848,7 @@ void GameTechRenderer::RenderPostProcessing() {
 	    UseShader(*vignetteShader);
 	    glUniform1i(glGetUniformLocation(vignetteShader->GetProgramID(), "vignetteOn"), GetVignetteOn());
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, bufferColourTex); //hdrTex currently holds raw scene
+		glBindTexture(GL_TEXTURE_2D, BTex); //hdrTex currently holds raw scene  //was bufferColourTex before adding edge detection
 		glUniform1i(glGetUniformLocation(vignetteShader->GetProgramID(), "diffuseTex"), 0);
 		glUniform2f(glGetUniformLocation(vignetteShader->GetProgramID(), "windowSize"), windowSize.x, windowSize.y);
 		Vector3 VignetteColour = Vector3(0.0, 0.0, 0.0); //different colours appear more intense at a given intensity (green)
@@ -854,7 +868,7 @@ void GameTechRenderer::RenderPostProcessing() {
 		UseShader(*hdrShader);
 		glUniform1i(glGetUniformLocation(hdrShader->GetProgramID(), "hdrOn"), GetHDROn()); //send bool to shader so it knows whether to output scene with or without post processing
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, BTex);//BTex holds vignetted processed scene (whether applied or not). (tonemapping should be done pretty much last)
+		glBindTexture(GL_TEXTURE_2D, hdrTex);//BTex holds vignetted processed scene (whether applied or not). (tonemapping should be done pretty much last) //was BTex before edge detection
 		glUniform1i(glGetUniformLocation(hdrShader->GetProgramID(), "hdrTex"), 0);
 		BindMesh(*fullscreenQuad); //using unitQuad instead of fullscreen quad
 		DrawBoundMesh();

--- a/TeamProject/GameTechRenderer.h
+++ b/TeamProject/GameTechRenderer.h
@@ -135,6 +135,7 @@ namespace NCL {
 			OGLShader* vignetteShader;
 			GLuint BDepthTex;
 			void RenderPostProcessing();
+			OGLShader* edgedetectShader;
 
 		};
 	}


### PR DESCRIPTION
Edge detection working although it has some small artifacting problems to do with the implementation, I know why this occurs but not sure how to solve it yet, but it's relatively minor so worth adding edge detection to main now.

The new implementation uses the surface normal at the world space position, which it finds using the depth map. It compares that to the surrounding surface normals and if any are vastly different it sets the colour to black.