### PR TITLE
Fix submeshes in binaries

### DIFF
--- a/MeshCompiler/main.cpp
+++ b/MeshCompiler/main.cpp
@@ -91,13 +91,7 @@ static void writeOptionalSubMeshNames(int& chunksWritten, std::ofstream& fs, con
 // - MSHB magic
 // - Rest of data in text mesh format, only converted to binary. Single precision floats and 32-bit integers
 
-static void convert(std::string_view source, std::string_view target) {
-	Mesh mesh;
-	bool ok = MshLoader::LoadTextMesh(std::string(source), mesh);
-	if (!ok) {
-		throw std::runtime_error("Failed to load mesh");
-	}
-
+static void convert(const Mesh& mesh, std::string_view target) {
 	std::ofstream fs(std::string(target), std::ios::binary);
 	fs.write("MSHB", 4);
 	write(fs, Version);
@@ -137,7 +131,25 @@ int main(int argc, char** argv) {
 
 	std::string_view source(argv[1]);
 	std::string_view target(argv[2]);
+
+	Mesh mesh;
+	bool ok = MshLoader::LoadTextMesh(std::string(source), mesh);
+	if (!ok) {
+		throw std::runtime_error("Failed to load mesh");
+	}
+
 	std::cout << "Converting " << source << " to " << target << std::endl;
 
-	convert(source, target);
+	convert(mesh, target);
+
+	// Check for round-trip accuracy
+	Mesh loaded;
+	ok = MshLoader::LoadBinaryMesh(target, loaded);
+	if (!ok) {
+		throw std::runtime_error("Failed to load mesh");
+	}
+
+	if (mesh != loaded) {
+		throw std::runtime_error("Round-trip check failed");
+	}
 }

--- a/MeshCompiler/main.cpp
+++ b/MeshCompiler/main.cpp
@@ -44,7 +44,7 @@ static void writeStrings(std::ofstream& fs, const std::vector<std::string>& data
 static int writeOptionalJointNames(int& chunksWritten, std::ofstream& fs, const std::vector<std::string>& data) {
 	if (data.empty()) return 0;
 	chunksWritten++;
-	
+
 	write(fs, MshLoader::GeometryChunkTypes::JointNames);
 	write(fs, data.size());
 
@@ -109,6 +109,7 @@ static void convert(const Mesh& mesh, std::string_view target) {
 	writeOptionalChunk(chunksWritten, fs, MshLoader::GeometryChunkTypes::VTangents, mesh.GetTangentData(), mesh.GetVertexCount());
 	writeOptionalChunk(chunksWritten, fs, MshLoader::GeometryChunkTypes::VTex0, mesh.GetTextureCoordData(), mesh.GetVertexCount());
 	writeOptionalChunk(chunksWritten, fs, MshLoader::GeometryChunkTypes::Indices, mesh.GetIndexData(), mesh.GetIndexCount());
+	writeOptionalChunk(chunksWritten, fs, MshLoader::GeometryChunkTypes::VWeightIndices, mesh.GetSkinIndexData(), mesh.GetVertexCount());
 	writeOptionalChunk(chunksWritten, fs, MshLoader::GeometryChunkTypes::VWeightValues, mesh.GetSkinWeightData(), mesh.GetVertexCount());
 	int jointNameCount = writeOptionalJointNames(chunksWritten, fs, mesh.GetJointNames());
 	writeOptionalJointParents(chunksWritten, fs, mesh.GetJointParents(), jointNameCount);
@@ -129,11 +130,11 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 
-	std::string_view source(argv[1]);
-	std::string_view target(argv[2]);
+	std::string source(argv[1]);
+	std::string target(argv[2]);
 
 	Mesh mesh;
-	bool ok = MshLoader::LoadTextMesh(std::string(source), mesh);
+	bool ok = MshLoader::LoadTextMesh(source, mesh);
 	if (!ok) {
 		throw std::runtime_error("Failed to load mesh");
 	}

--- a/NCLCoreClasses/Matrix.h
+++ b/NCLCoreClasses/Matrix.h
@@ -60,6 +60,18 @@ namespace NCL::Maths {
         }
     };
 
+    template <typename T, uint32_t rows, uint32_t cols>
+    bool operator==(const MatrixTemplate<T, rows, cols>& lhs, const MatrixTemplate<T, rows, cols>& rhs) {
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                if (lhs.array[i][j] != rhs.array[i][j]) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     using Matrix2 = MatrixTemplate<float, 2, 2>;
     using Matrix3 = MatrixTemplate<float, 3, 3>;
     using Matrix4 = MatrixTemplate<float, 4, 4>;

--- a/NCLCoreClasses/Mesh.cpp
+++ b/NCLCoreClasses/Mesh.cpp
@@ -17,6 +17,30 @@ Mesh::Mesh()	{
 Mesh::~Mesh()	{
 }
 
+bool Mesh::operator==(const Mesh& rhs) const {
+#define EQUAL(field) (field == rhs. field)
+	if (this == &rhs) return true;
+
+	return EQUAL(primType)
+		&& EQUAL(debugName)
+		&& EQUAL(assetID)
+		&& EQUAL(boundingRadius)
+		&& EQUAL(positions)
+		&& EQUAL(texCoords)
+		&& EQUAL(colours)
+		&& EQUAL(normals)
+		&& EQUAL(tangents)
+		&& EQUAL(indices)
+		&& EQUAL(subMeshes)
+		&& EQUAL(subMeshNames)
+		&& EQUAL(skinWeights)
+		&& EQUAL(skinIndices)
+		&& EQUAL(jointNames)
+		&& EQUAL(bindPose)
+		&& EQUAL(inverseBindPose);
+#undef EQUAL
+}
+
 bool Mesh::HasTriangle(unsigned int i) const {
 	int triCount = 0;
 	if (GetIndexCount() > 0) {

--- a/NCLCoreClasses/Mesh.h
+++ b/NCLCoreClasses/Mesh.h
@@ -60,6 +60,10 @@ namespace NCL::Rendering {
 		int start = 0;
 		int count = 0;
 		//int base  = 0;
+
+		bool operator==(const SubMesh& rhs) const {
+			return start == rhs.start && count == rhs.count;
+		}
 	};
 
 	class Mesh	{
@@ -77,6 +81,8 @@ namespace NCL::Rendering {
 
 		Mesh();
 		virtual ~Mesh();
+
+		bool operator==(const Mesh& rhs) const;
 
 		GeometryPrimitive::Type GetPrimitiveType() const {
 			return primType;

--- a/NCLCoreClasses/MshLoader.cpp
+++ b/NCLCoreClasses/MshLoader.cpp
@@ -38,6 +38,14 @@ std::vector<T> readVector(std::ifstream& fs, int size) {
 	return out;
 }
 
+// Read a vector with a size stored before it
+template <typename T>
+std::vector<T> readSizedVector(std::ifstream& fs) {
+	size_t count; read<size_t>(fs, count);
+	return readVector<T>(fs, count);
+}
+
+// Read a vector of null-terminated strings
 std::vector<std::string> readStrings(std::ifstream& fs, int size) {
 	std::vector<std::string> out;
 	for (int i = 0; i < size; i++) {
@@ -49,6 +57,7 @@ std::vector<std::string> readStrings(std::ifstream& fs, int size) {
 				value += ch;
 			}
 			else {
+				out.push_back(value);
 				break;
 			}
 
@@ -118,6 +127,11 @@ bool NCL::Rendering::MshLoader::LoadBinaryMesh(const std::string& filename, Mesh
 		} case GeometryChunkTypes::VWeightValues: {
 			auto weights = readVector<Vector4>(fs, numVertexes);
 			destinationMesh.SetVertexSkinWeights(weights);
+			break;
+		} case GeometryChunkTypes::VWeightIndices: {
+			auto weights = readVector<Vector4i>(fs, numVertexes);
+			destinationMesh.SetVertexSkinIndices(weights);
+			break;
 		} case GeometryChunkTypes::Indices: {
 			auto indexes = readVector<unsigned int>(fs, numIndexes);
 			destinationMesh.SetVertexIndices(indexes);
@@ -129,6 +143,23 @@ bool NCL::Rendering::MshLoader::LoadBinaryMesh(const std::string& filename, Mesh
 		} case GeometryChunkTypes::SubMeshNames: {
 			auto names = readStrings(fs, numMeshes);
 			destinationMesh.SetSubMeshNames(names);
+			break;
+		} case GeometryChunkTypes::JointNames: {
+			size_t count; read(fs, count);
+			auto names = readStrings(fs, count);
+			destinationMesh.SetJointNames(names);
+			break;
+		} case GeometryChunkTypes::JointParents: {
+			auto parents = readSizedVector<int>(fs);
+			destinationMesh.SetJointParents(parents);
+			break;
+		} case GeometryChunkTypes::BindPose: {
+			auto pose = readSizedVector<Matrix4>(fs);
+			destinationMesh.SetBindPose(pose);
+			break;
+		} case GeometryChunkTypes::BindPoseInv: {
+			auto pose = readSizedVector<Matrix4>(fs);
+			destinationMesh.SetInverseBindPose(pose);
 			break;
 		} default: {
 			std::cerr << __FUNCTION__ << " Unknown chunk type " << (int)type << " at offset 0x" << std::hex << fs.tellg() << std::dec << " in " << filename << std::endl;

--- a/NCLCoreClasses/Vector.h
+++ b/NCLCoreClasses/Vector.h
@@ -29,6 +29,16 @@ namespace NCL::Maths {
         }
     };
 
+    template <typename T, uint32_t n>
+    bool operator==(const VectorTemplate<T, n>& lhs, const VectorTemplate<T, n>& rhs) {
+        for (int i = 0; i < n; i++) {
+            if (lhs.array[i] != rhs.array[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     using Vector2 = VectorTemplate<float, 2>;
     // DEPRECATED: Prefer btVector3
     using Vector3 = VectorTemplate<float, 3>;

--- a/cmake/copy_assets.cmake
+++ b/cmake/copy_assets.cmake
@@ -1,6 +1,12 @@
 set(TEXTURE_EXTENSIONS ".jpg" ".png" ".dds")
 set(MIP_LEVELS 8)
 
+# Extra files that need to be copied, but do not live in assets
+set(EXTRA_FILES
+    Credits.txt
+    default-config.jsonc
+)
+
 macro(process_file)
     set(outvar ${ARGV0})
     set(file ${ARGV1})
@@ -57,6 +63,16 @@ macro(copy_assets)
             COMMAND ${CMAKE_COMMAND} -E copy
             ${processed}
             ${destination}/${relative}
+        )
+    endforeach()
+
+    cmake_path(GET destination PARENT_PATH assetParentDir)
+    foreach(file ${EXTRA_FILES})
+        add_custom_command(
+            TARGET ${afterTarget} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+            ${CMAKE_SOURCE_DIR}/${file}
+            ${assetParentDir}/${file}
         )
     endforeach()
 


### PR DESCRIPTION
Several fields were not being read/written at all. Added a check that a binary reads to the same mesh as what was just written

Closes #268 