### PR TITLE
Handle font bearings

### DIFF
--- a/NCLCoreClasses/SimpleFont.cpp
+++ b/NCLCoreClasses/SimpleFont.cpp
@@ -31,6 +31,8 @@ void SimpleFont::BuildVerticesForString(const std::string& text, const Maths::Ve
         auto& info = data->second;
 
         Vector3 topLeft = Vector3(currentX, currentY, 0) * size;
+        topLeft -= Vector3(info.bearing, 0) * size;
+
         Vector3 bottomRight = topLeft + Vector3(info.size, 0) * size;
         Vector3 bottomLeft(topLeft.x, bottomRight.y, 0);
         Vector3 topRight(bottomRight.x, topLeft.y, 0);
@@ -60,9 +62,7 @@ void SimpleFont::BuildVerticesForString(const std::string& text, const Maths::Ve
         positions.push_back(bottomLeft);
         texCoords.push_back(uvBottomLeft);
 
-        // TODO: Handle advance properly
-        //currentX += (topRight.x - topLeft.x);
-        currentX += (info.advance / 64) / ScreenSize.x;
+        currentX += info.advance;
     }
 }
 
@@ -94,12 +94,18 @@ SimpleFont::SimpleFont(const std::string&filename, std::shared_ptr<Texture> text
 SimpleFont::~SimpleFont()	{
 }
 
+// Get the next power of 2 that is >= `i`
 int nextPower2(int i) {
     int candidate = 1;
     while (candidate < i) {
         candidate = candidate * 2;
     }
     return candidate;
+}
+
+// Convert a 26.6 fixed point integer into a float
+float fixedToFloat(int fixed) {
+    return fixed / 64.0f;
 }
 
 int SimpleFont::InitializeFreeType(const std::string& filename, std::shared_ptr<Texture> texture) {
@@ -133,8 +139,8 @@ int SimpleFont::InitializeFreeType(const std::string& filename, std::shared_ptr<
         }
         GlyphData data;
         data.ch = c;
-        data.advance = face->glyph->advance.x;
-        data.bearing = { float(face->glyph->bitmap_left), float(face->glyph->bitmap_top) };
+        data.advance = fixedToFloat(face->glyph->advance.x);
+        data.bearing = { face->glyph->bitmap_left, face->glyph->bitmap_top };
 
         data.size = {
             face->glyph->bitmap.width, face->glyph->bitmap.rows
@@ -173,17 +179,16 @@ int SimpleFont::InitializeFreeType(const std::string& filename, std::shared_ptr<
             memcpy(dataBegin + (y * texture->width), glyph.data.data() + (y * glyph.size.x), glyph.size.x);
         }
 
+        // Keep everything in screen multiples, for easier use with NDCs
         Character ch;
-        Vector2 sizeVec = Vector2(glyph.size.x, glyph.size.y);
-        ch.size = sizeVec / ScreenSize;
-        ch.bearing = glyph.bearing;
+        ch.size = Vector2(glyph.size.x, glyph.size.y) / ScreenSize;
+        ch.bearing = Vector2(glyph.bearing.x, glyph.bearing.y) / ScreenSize;
+        ch.advance = glyph.advance / ScreenSize.x;
 
         int pixelsLeft = col * maxSize.x;
         int pixelsTop = row * maxSize.y;
-
         ch.uvTopLeft = Vector2(pixelsLeft, pixelsTop) * pixelSize;
-        ch.uvBottomRight = ch.uvTopLeft + (pixelSize * sizeVec);
-        ch.advance = glyph.advance;
+        ch.uvBottomRight = ch.uvTopLeft + (pixelSize * Vector2(glyph.size.x, glyph.size.y));
 
         characters[glyph.ch] = ch;
     }

--- a/NCLCoreClasses/SimpleFont.h
+++ b/NCLCoreClasses/SimpleFont.h
@@ -11,21 +11,25 @@ namespace NCL {
 
 		class SimpleFont {
 		public:
+            // A glyph that hasn't yet been inserted into an atlas
+            // sizes are in pixels
             struct GlyphData {
-                Vector2ui size;
-                Vector2 bearing;
-                int advance;
+                Vector2ui size; // Size of data
+                Vector2i bearing; // Offset from baseline to top/left
+                float advance; // Offset to reach the next glyph
                 std::vector<char> data;
                 char ch;
             };
 
-            // Metrics of a character glyph
+            // A reference to a glyph in an atlas
+            // sizes are in screens, (arbritray unit, but consistent across resolutions)
+            // easier to work with in NDC space
             struct Character {
-                Vector2 size;      // Size of glyph
+                Vector2 size; // Size of glyph
                 Vector2   bearing;   // Offset from baseline to left/top of glyph
                 Vector2 uvTopLeft;
                 Vector2 uvBottomRight;
-                unsigned int advance;   // Offset to advance to next glyph
+                float advance;   // Offset to advance to next glyph
             };
 
 

--- a/TeamProject/CreditsScreen.h
+++ b/TeamProject/CreditsScreen.h
@@ -49,7 +49,7 @@ public:
 		}
 
 		// ~80 chars at 720p
-		Debug::Print("Oh hi there. I see you found a feature (TM)", Vector2(0, yPos - 0.50f));
+		Debug::Print("Oh hi there. I see you found a feature (TM). Because it's a feature,\nI don't need to care about bugs", Vector2(0, yPos - 0.50f), Vector4(1, 1, 1, 1), 0.9f);
 		Debug::Print(text, Vector2(0, yPos), Vector4(1, 1, 1, 1), TextScale);
 		yPos -= (Speed + speedup) * dt;
 


### PR DESCRIPTION
Handling bearings in TTF fonts, needed for characters such as `,` to render properly.

Also standardises units in  `Character` to be in screen multiples.