### PR TITLE
Check process tick >= 0.

### DIFF
--- a/TeamProject/Multiplayer/Server.cpp
+++ b/TeamProject/Multiplayer/Server.cpp
@@ -157,7 +157,7 @@ namespace Multiplayer {
                     std::cout << ConsoleTextColor::DEFAULT;
 #endif
                     for (diff; diff > 0; diff--) {
-                        m_buffer[m_processTick % TICK_BUFFER_SIZE].clear();
+                        if (m_processTick >= 0) m_buffer[m_processTick % TICK_BUFFER_SIZE].clear();
                         m_processTick++;
                     }
                     m_tickCount = currentPacket->GetSequenceNumber();


### PR DESCRIPTION
A fix for players crashing upon game start. When network was trying to catchup to the tick count, the previous packets were cleared based on where the process tick was at. However, the process tick starts at below zero. This fixes this issue.