### PR TITLE
Fix PS5 networking

### DIFF
--- a/CSC8503CoreClasses/AliveState.h
+++ b/CSC8503CoreClasses/AliveState.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace NCL::CSC8503 {
+    enum class AliveState {
+        DEAD,
+        ALIVE
+    };
+}

--- a/CSC8503CoreClasses/CMakeLists.txt
+++ b/CSC8503CoreClasses/CMakeLists.txt
@@ -66,6 +66,7 @@ source_group("Physics" FILES ${Physics})
 
 set(Header_Files
 	"Debug.h"
+    "AliveState.h"
 	"GameObject.h"
 	"GameWorld.h"
     "MeshMaterial.h"

--- a/CSC8503CoreClasses/GameObject.cpp
+++ b/CSC8503CoreClasses/GameObject.cpp
@@ -17,8 +17,6 @@ GameObject::GameObject(const std::string& objectName)	{
 	physicsObject	= nullptr;
 	renderObject	= nullptr;
 	networkObject	= nullptr;
-
-    states = std::make_unique<StateBuffer>();
 }
 
 GameObject::~GameObject()	{

--- a/CSC8503CoreClasses/GameObject.h
+++ b/CSC8503CoreClasses/GameObject.h
@@ -210,7 +210,6 @@ namespace NCL::CSC8503 {
         PointLight* light = nullptr;
         Lobbies::User* owner = nullptr;
 
-        std::unique_ptr<WorldState::StateBuffer> states;
         std::shared_mutex tickMutex;
         int currentTick = 0;
         int lastTick = 0;

--- a/CSC8503CoreClasses/GameObject.h
+++ b/CSC8503CoreClasses/GameObject.h
@@ -12,18 +12,13 @@
 #include "../TeamProject/Multiplayer/User.hpp"
 #include "WorldState.h"
 #include "StateUpdater.h"
+#include "AliveState.h"
 
 namespace Packet {
     class Packet;
 }
 
 namespace NCL::CSC8503 {
-
-    enum class ObjectState {
-        DEAD,
-        ALIVE
-    };
-
     class NetworkObject;
     class RenderObject;
     class PhysicsObject;
@@ -187,8 +182,8 @@ namespace NCL::CSC8503 {
         void setDeleted() { deleted = true; }
         bool isDeleted() const { return deleted; }
 
-        void SetState(ObjectState newState) { state = newState; }
-        ObjectState GetState() const { return state; }
+        void SetState(AliveState newState) { state = newState; }
+        AliveState GetState() const { return state; }
 		bool GetIsAnimated() { return animated; }
 		void SetIsAnimated(bool a) { animated = a; }
 
@@ -219,11 +214,11 @@ namespace NCL::CSC8503 {
         std::shared_mutex tickMutex;
         int currentTick = 0;
         int lastTick = 0;
-	    
+
         float elapsedTime = 0;
 
 		float jumpPadStrength = 0.0f;
 
-        ObjectState state;
+        AliveState state;
 	};
 }

--- a/CSC8503CoreClasses/RenderObject.h
+++ b/CSC8503CoreClasses/RenderObject.h
@@ -81,7 +81,7 @@ namespace NCL {
 
 		protected:
 			GameObject* parent;
-			Buffer* buffer;
+			Buffer* buffer = nullptr;
 			std::shared_ptr<Mesh> mesh;
 			Vector4		colour = Vector4(1, 1, 0, 0.99);
 			bool isFlat = false;

--- a/CSC8503CoreClasses/WorldState.h
+++ b/CSC8503CoreClasses/WorldState.h
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <optional>
 
 namespace WorldState {
     using StateValue = std::variant<btVector3, btQuaternion, float, int>;
@@ -60,7 +61,7 @@ namespace WorldState {
             }
             return false;
         }
-        
+
         /**
          * @brief Remove all states and their values.
          */
@@ -83,7 +84,7 @@ namespace WorldState {
     /**
      * @brief An object returned by the state buffer for reading and writing to
      * a state buffer.
-     * 
+     *
      * The reading mutex does not handling reading and writing operations to
      * the state but handles locking / unlocking the state buffer update.
      */
@@ -133,74 +134,88 @@ namespace WorldState {
     /**
      * @brief State buffer contains 3 different buffers for reading, writing
      * and interpolating world states.
-     * 
+     *
      * It's main use it to interpolate world states between current and read
      * while still allowing writes to the write state so that state swapping is
      * smooth and without delay.
      */
     class StateBuffer {
     public:
-        StateBuffer() {
-            m_stateMutexes = new std::shared_mutex[3];
-        }
+        using StateArray = std::array<ObjectState, 3>;
+
         ~StateBuffer() {
             delete[] m_stateMutexes;
         }
 
         /**
          * @brief Get the current ObjectState.
-         * 
+         *
          * Calling this function multiple times on the same thread without
          * unlocking will most likely result in a deadlock.
          */
         std::pair<ObjectState*, std::shared_lock<std::shared_mutex>> GetCurrentState() {
+            getStates();
             std::shared_lock lock(m_stateMutexes[current]);
-            return std::make_pair(&m_states[current], std::move(lock));
+            return std::make_pair(&getStates()[current], std::move(lock));
         }
 
         /**
          * @brief Get the ObjectState to read from.
-         * 
+         *
          * Calling this function multiple times on the same thread without
          * unlocking will most likely result in a deadlock.
          */
         std::pair<ObjectState*, std::shared_lock<std::shared_mutex>> GetReadState() {
+            getStates();
             std::shared_lock lock(m_stateMutexes[read]);
-            return std::make_pair(&m_states[read], std::move(lock));
+            return std::make_pair(&getStates()[read], std::move(lock));
         }
 
         /**
          * @brief Get the ObjectState to write to.
-         * 
+         *
          * Calling this function multiple times on the same thread without
          * unlocking will most likely result in a deadlock.
          */
         std::pair<ObjectState*, std::shared_lock<std::shared_mutex>> GetWriteState() {
+            getStates();
             std::shared_lock lock(m_stateMutexes[write]);
-            return std::make_pair(&m_states[write], std::move(lock));
+            return std::make_pair(&getStates()[write], std::move(lock));
+        }
+
+        StateArray& getStates() {
+            if (!m_states.has_value()) {
+                m_states.emplace();
+            }
+            m_stateMutexes = new std::shared_mutex[3];
+            return m_states.value();
         }
 
         /**
          * @brief Update the world states.
-         * 
+         *
          * Current becomes the previous read object state.
          * Read becomes the previous write object state.
          * Write is cleared.
          */
         void UpdateBuffer() {
+            if (m_states == std::nullopt) {
+                return;
+            }
+
             std::unique_lock currentLock(m_stateMutexes[current]);
             std::unique_lock readLock(m_stateMutexes[read]);
             std::unique_lock writeLock(m_stateMutexes[write]);
 
             current = read;
             read = write;
-            write = (write + 1) % m_states.size();
-            m_states[write].Clear();
+            write = (write + 1) % m_states->size();
+            getStates()[write].Clear();
         }
 
     private:
-        std::array<ObjectState, 3> m_states;
-        std::shared_mutex* m_stateMutexes;
+        std::shared_mutex* m_stateMutexes = nullptr;
+        std::optional<std::array<ObjectState, 3>> m_states;
 
         int current = 0;
         int read = 1;

--- a/NCLCoreClasses/JoystickController.cpp
+++ b/NCLCoreClasses/JoystickController.cpp
@@ -52,8 +52,8 @@ namespace NCL {
 
         case DigitalControl::WorldRollLeft: return buttonPressed({ Button::PadLeft, Button::L1 }, false, true);
         case DigitalControl::WorldRollRight: return buttonPressed({ Button::PadRight, Button::R1 }, false, true);
-        case DigitalControl::WorldPitchUp: return buttonPressed({ Button::PadUp, Button::PsTriangle }, false, true);
-        case DigitalControl::WorldPitchDown: return buttonPressed({ Button::PadDown, Button::PsSquare }, false, true);
+        case DigitalControl::WorldPitchUp: return buttonPressed({ Button::PadUp }, false, true);
+        case DigitalControl::WorldPitchDown: return buttonPressed({ Button::PadDown }, false, true);
 
         case DigitalControl::DebugBulletOverlay: return buttonPressed(Button::PadUp, true, true);
         case DigitalControl::DebugFreeCam: return buttonPressed(Button::PadRight, true, true);
@@ -65,6 +65,8 @@ namespace NCL {
         case DigitalControl::MenuConfirm: return buttonPressed(Button::A, false, true);
         case DigitalControl::Pause: case DigitalControl::Unpause:
             return buttonPressed(Button::Start, false, true);
+        case DigitalControl::Scoreboard: // We can't use select on PS5 :(, check for it still since it works on other controllers
+            return buttonPressed(Button::PsTriangle, false, true) >= fireThreshold || buttonPressed(Button::Select);
         case DigitalControl::PauseQuit: return buttonPressed(Button::Start, true, true);
         case DigitalControl::ThirdPerson:
         case DigitalControl::DebugReloadWorld:

--- a/TeamProject/GameTechAGCRenderer.cpp
+++ b/TeamProject/GameTechAGCRenderer.cpp
@@ -617,7 +617,7 @@ void GameTechAGCRenderer::RenderDebugText() {
 void GameTechAGCRenderer::UpdateObjectList() {
 	currentFrame->objects.begin(currentFrame);
 	for (auto g : frameObjects) {
-		ObjectState state;
+		::ObjectState state;
 		Matrix4 transMatrix;
 		g->getParent()->GetTransform().getOpenGLMatrix((float*)&transMatrix);
 		state.modelMatrix = transMatrix * Matrix::Scale(g->getParent()->getRenderScale());
@@ -664,7 +664,7 @@ void GameTechAGCRenderer::UpdateObjectList() {
 		for (int i = 0; i < g->GetMesh()->GetSubMeshCount(); i++) {
 			auto subMesh = g->GetMesh()->GetSubMesh(i);
 			auto layer = g->getMaterial() ? g->getMaterial()->GetLayer(i) : nullptr;
-			state.colour = (l && l->useColor) ? g->GetColour() : Vector4(1, 1, 1, 1);
+			state.colour = (layer && layer->useColor) ? g->GetColour() : Vector4(1, 1, 1, 1);
 
 			auto t = layer ? layer->diffuse : nullptr;
 			state.texIndex = t ? t->GetAssetID() : NULLTEX;
@@ -680,7 +680,7 @@ void GameTechAGCRenderer::UpdateObjectList() {
 			state.numElements = subMesh->count;
 			// This behaviour is inverted from OpenGL for compatibility with HLSL UVs
 			state.invertY = !(layer && layer->invertY);
-			currentFrame->data.WriteData<ObjectState>(state);
+			currentFrame->data.WriteData(state);
 		}
 
 	}
@@ -711,10 +711,10 @@ void GameTechAGCRenderer::UpdateObjectList() {
 	currentFrame->lasers.begin(currentFrame);
 	for (auto& laser : lasers) {
 		LaserState state;
-		state.start = laser->startPos;
-		state.end = laser->endPos;
+		state.start = laser->GetStartPos();
+		state.end = laser->GetEndPos();
 		state.thickness = 0.25f;
-		state.colour = Color::GetPlayerColor(laser->id);
+		state.colour = laser->GetColor();
 		currentFrame->data.WriteData(state);
 	}
 	currentFrame->lasers.end(currentFrame);

--- a/TeamProject/Health.cpp
+++ b/TeamProject/Health.cpp
@@ -12,7 +12,7 @@ namespace NCL {
             elapsed += dt;
 
             // Regenerating HealthAttrib.
-            if (GetHealthState() == HealthState::ALIVE && elapsed - lastHit >= regenDelay) {
+            if (GetHealthState() == AliveState::ALIVE && elapsed - lastHit >= regenDelay) {
                 SetCurrentHealth(currentHealth + (regenRate * dt));
             }
         }

--- a/TeamProject/Health.h
+++ b/TeamProject/Health.h
@@ -5,18 +5,14 @@
 #include <shared_mutex>
 
 #include "StateUpdater.h"
+#include "AliveState.h"
 
 namespace NCL::CSC8503 {
     class GameObject;
 
-    enum class HealthState {
-        ALIVE,
-        DEAD
-    };
-
     /**
      * @brief An entity that can be damaged.
-     * 
+     *
      * This entity is to be used as an abstract class to inherit from. It does
      * NOT update GameObject states. If you want state updates for GameObject,
      * you must explicitly call base class update functions.
@@ -44,7 +40,7 @@ namespace NCL::CSC8503 {
         float GetCurrentHealth() const { return currentHealth; }
 
         /**
-         * @brief Set how much HP to regenerate per second. 
+         * @brief Set how much HP to regenerate per second.
          */
         void SetRegenerationRate(float rate) { regenRate = rate; }
         float GetRegenerationRate() const { return regenRate; }
@@ -58,12 +54,12 @@ namespace NCL::CSC8503 {
         void SetInvulnerableWindow(float time) { invulnerableWindow = time; }
         float GetInvulernableWindow() { return invulnerableWindow; }
 
-        void Respawn() { 
+        void Respawn() {
             SetCurrentHealth(GetMaxHealth());
             lastSpawn = elapsed;
         }
 
-        HealthState GetHealthState() { return currentHealth == 0 ? HealthState::DEAD : HealthState::ALIVE; }
+        AliveState GetHealthState() { return currentHealth == 0 ? AliveState::DEAD : AliveState::ALIVE; }
         GameObject* GetParent() { return parent; }
 
     protected:
@@ -120,7 +116,7 @@ namespace NCL::CSC8503 {
         float damage = 0;
 
         DamageType damageType = DamageType::DISCRETE;
-        
+
         HealthAttrib* target = nullptr; // Reference to health of enemy.
         HealthAttrib* health = nullptr; // Reference to own health.
 

--- a/TeamProject/LaserObject.cpp
+++ b/TeamProject/LaserObject.cpp
@@ -1,7 +1,6 @@
 #include "LaserObject.h"
 #include "WorldState.h"
 #include "Multiplayer/GamePackets.hpp"
-#include "GameTechRenderer.h"
 #include "Shoot.h"
 
 
@@ -19,7 +18,7 @@ void LaserObject::Update(float dt) {
 
 void LaserObject::UpdateWorldState() {
     auto [writeState, lock] = GetWorldStates()->GetWriteState();
-    
+
     std::unique_lock stateLock = writeState->Lock();
     writeState->UpdateState(StateType::StartPos, startPos);
     writeState->UpdateState(StateType::EndPos, endPos);
@@ -40,10 +39,10 @@ void LaserObject::UpdateFromWorldState(float dt) {
 
     StateValue currentEndPosValue;
     StateValue targetEndPosValue;
-    
+
     StateValue currentCollisionNormalValue;
     StateValue targetCollisionNormalValue;
-    
+
     // Reading.
     std::shared_lock currentStateLock = current->Lock_Shared();
     std::shared_lock readStateLock = read->Lock_Shared();
@@ -72,7 +71,7 @@ void LaserObject::UpdateFromWorldState(float dt) {
             lerp(currentStartPos.z(), targetStartPos.z(), weight)
         );
         startPos = interpolated;
-    } 
+    }
 
     // End Position.
     if (hasCurrentEndPos && hasCurrentEndPos) {
@@ -85,7 +84,7 @@ void LaserObject::UpdateFromWorldState(float dt) {
         );
         endPos = interpolated;
 
-    } 
+    }
 
     // Collision Normal (does not want interpolation.
     if (hasTargetCollisionNormal) {
@@ -103,14 +102,14 @@ std::vector<std::shared_ptr<Packet::Packet>> LaserObject::CreatePackets(int sequ
     StateValue collisionNormalValue;
 
     std::shared_lock readStateLock = read->Lock_Shared();
-    
+
     bool hasStartPos = read->ReadState(StateType::StartPos, &startPosValue);
     bool hasEndPos = read->ReadState(StateType::EndPos, &endPosValue);
     bool hasCollisionNormal = read->ReadState(StateType::Normal, &collisionNormalValue);
 
     readStateLock.unlock();
     readLock.unlock();
-    
+
     if (hasStartPos && hasEndPos && hasCollisionNormal) {
         packets.push_back(std::move(std::make_shared<Packet::LaserPacket>(
             GetWorldID(),

--- a/TeamProject/PlayerObject.h
+++ b/TeamProject/PlayerObject.h
@@ -166,7 +166,7 @@ namespace NCL::CSC8503 {
 		float jumpPadHeight = 0.0f;
 		std::list<GameObject*> collidedObjects;
 		Type collisionType;
-		ObjectState state;
+		AliveState state;
 		float yawOverride = -1000.0f;
 
 		btQuaternion camRotOffset;

--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -13,7 +13,7 @@
 #include "Colors.h"
 #include "Shoot.h"
 #include "Health.h"
-#include "MeshAnimation.h" //temporarily added for testing 
+#include "MeshAnimation.h" //temporarily added for testing
 
 #include "Window.h"
 #include "Config.h"
@@ -119,7 +119,7 @@ void TutorialGame::UpdateGame(float dt) {
 
     profiler.startSection("Update Audio");
     audioEngine.Update(&world->GetMainCamera());
-    
+
     clearGraveyard();
     profiler.startSection("Prepare Render");
     bulletWorld->debugDrawWorld();
@@ -143,7 +143,7 @@ void TutorialGame::UpdateGame(float dt) {
 
 
 void TutorialGame::UpdatePlayer(float dt) {
-    if (player->GetHealthAttrib()->GetHealthState() == HealthState::DEAD) {
+    if (player->GetHealthAttrib()->GetHealthState() == AliveState::DEAD) {
         Respawn* instance = Respawn::GetInstance();
         RespawnPoint* respawn;
 
@@ -367,7 +367,7 @@ PlayerObject* TutorialGame::InitPlayer(btVector3 position, btVector3 upDir, bool
     newPlayer->setType(GameObject::Type::Player);
 
     newPlayer->SetIsAnimated(true); //maybe better to manage this wherever animations are being applied rather than here but for testing this is probably fine
-    newPlayer->setRenderer(renderer); 
+    newPlayer->setRenderer(renderer);
     Respawn::GetInstance()->InsertPlayerObj(newPlayer);
     return newPlayer;
 }
@@ -391,7 +391,7 @@ GameObject* TutorialGame::AddGunToWorld(const Vector3& position, Vector3 dimensi
     // Setting render object
     gun->SetRenderObject(new RenderObject(gun, resourceManager->getMeshes().get("VD_Raygun_Cartoony_Rigged1.msh"), resourceManager->getMaterials().get("VD_Raygun_Cartoony_Rigged1.mat")));
     gun->setType(GameObject::Type::Gun);
-    
+
     world->AddGameObject(gun);
 
     return gun;
@@ -441,7 +441,7 @@ PlayerObject* TutorialGame::AddPlayerCapsuleToWorld(const Vector3& position, flo
     // Creating a Bullet collision shape for the capsule
     btCollisionShape* playerShape = new btCapsuleShape(radius, height);
 
-    // Setting the render object for the capsule 
+    // Setting the render object for the capsule
     player->SetRenderObject(new RenderObject(player, resourceManager->getMeshes().get("RacerGuy/RacerGuy2.msh"), resourceManager->getMaterials().get("RacerGuy.mat"))); //defaultTexture
     player->CreateAnimationObject();
     player->CorrectAnimation();
@@ -596,7 +596,7 @@ void TutorialGame::Start() {
             PlayerObject* player = instance->InitPlayer(respawn->position, respawn->orientation, mainPlayer);
             player->SetWorldID(user.GetUserID());
             player->SetOwner(user);
-            
+
             LaserObject* laser = player->GetLaser();
             instance->renderer->TrackLaser(laser);
 

--- a/TeamProject/Wanderer.cpp
+++ b/TeamProject/Wanderer.cpp
@@ -113,7 +113,7 @@ void Wanderer::Update(float dt) {
 	health->Update(dt);
 	attack->Update(dt);
 
-	if (health->GetHealthState() == HealthState::DEAD) {
+	if (health->GetHealthState() == AliveState::DEAD) {
 		DestroyWanderer();
 		return;
 	}


### PR DESCRIPTION
Fix 2 types having the same name and 2 enums being identical. Blame Tom

Lazy init WorldState mutexes, as excessive mutexes cause a crash on PS5