### PR TITLE
hover and double player updates fix

### DIFF
--- a/TeamProject/GameScreen.h
+++ b/TeamProject/GameScreen.h
@@ -17,7 +17,7 @@ namespace NCL::CSC8503 {
 
         PushdownResult OnUpdate(float dt, PushdownState** newState) override {
             game->UpdateGame(dt);
-
+            game->UpdatePlayer(dt);
             if (game->getSPEnd()) {
                 *newState = new EndScreenSP(controller, game, game->GetSPMode()->getScore());
                 std::cout << "Singeplayer game ended" << std::endl;

--- a/TeamProject/PlayerController.cpp
+++ b/TeamProject/PlayerController.cpp
@@ -74,6 +74,8 @@ void PlayerController::UpdateMovement(float dt) {
     RotationCalculations();
  
     CameraMovement();
+    CheckForGround();
+
     GroundNormalCalculations();
     MovementCalculations(dt);
     HandleJumping();
@@ -331,6 +333,17 @@ void PlayerController::CameraMovement() {
         player->SetGunTransform(camera->GetPitch(), camera->GetYaw(), playerCamPos);
     }
 };
+
+void PlayerController::CheckForGround() {
+    if (inAirTime > 0 || player->getCollided() == 0) return;
+    btVector3 btBelowPlayerPos = btPlayerPos;
+    btBelowPlayerPos -= (upDirection * 50);
+    btCollisionWorld::ClosestRayResultCallback callback(btPlayerPos, btBelowPlayerPos);
+    bulletWorld->rayTest(btPlayerPos, btBelowPlayerPos, callback);
+    if (!callback.hasHit()) {
+        player->setCollided(0);
+    }
+}
 
 //if on ground, movement based on floor angle
 void PlayerController::GroundNormalCalculations() {

--- a/TeamProject/PlayerController.h
+++ b/TeamProject/PlayerController.h
@@ -193,6 +193,7 @@ namespace NCL {
 			void HandleYaw();
 			void RotationCalculations();
 			void CameraMovement();
+			void CheckForGround();
 			void GroundNormalCalculations();
 			void MovementCalculations(float dt);
 			void HandleJumping();

--- a/TeamProject/PlayerObject.cpp
+++ b/TeamProject/PlayerObject.cpp
@@ -45,10 +45,10 @@ void PlayerObject::SetColor(btVector4 color) {
     laser->SetColor(color);
 }
 
+
 void PlayerObject::Update(float dt) {
     attack->Update(dt);
     health->Update(dt);
-
     upDirection = CalculateUpDirection(dt);
 
     rightDirection = CalculateRightDirection(upDirection);

--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -120,8 +120,6 @@ void TutorialGame::UpdateGame(float dt) {
     // Check for collisions
     CheckCollisions();
 
-    if (playerController && !isPlayerUpdatePaused) UpdatePlayer(dt);
-
     profiler.startSection("Update Audio");
     audioEngine.Update(&world->GetMainCamera());
 
@@ -185,7 +183,6 @@ void TutorialGame::UpdatePlayer(float dt, bool camOnly) {
     }
     else {
  
-      
         //player Movement
         if (camOnly) {
             playerController->UpdateCamOnly();


### PR DESCRIPTION
Added a ray check to the onFloor as a backup to stop the hovering problem
player Update was being called twice, once in gameScreen and once in UpdateGame which was a problem, fixed that