### PR TITLE
Add Ram usage next to FPS counter

### DIFF
--- a/TeamProject/Profiler.cpp
+++ b/TeamProject/Profiler.cpp
@@ -18,12 +18,12 @@ namespace NCL::CSC8503 {
 
 	void Profiler::printTimes()
 	{
-		Vector2 position(0, 0.1);
+		Vector2 position(1.7, 0.15);
 		for (auto& section : times) {
 			std::stringstream str;
 			str << section.first << ": " << std::chrono::duration_cast<std::chrono::microseconds>(section.second).count() / 1000.0f << "ms";
-			Debug::Print(str.str(), position);
-			position.y += 0.05;
+			Debug::Print(str.str(), position, { 1, 1, 1, 1 }, 0.5f);
+			position.y += 0.07;
 		}
 	}
 

--- a/TeamProject/TutorialGame.cpp
+++ b/TeamProject/TutorialGame.cpp
@@ -94,7 +94,7 @@ void TutorialGame::UpdateGame(float dt) {
     //float maxDt = btMin(PHYSICS_PERIOD, dt);
     int steps = bulletWorld->stepSimulation(dt, substeps, PHYSICS_PERIOD);
 
-    profiler.startSection("Network Updates");
+    profiler.startSection("Network");
     if (server != nullptr) {
         std::unique_lock ticklock = server->LockTick();
 
@@ -109,24 +109,24 @@ void TutorialGame::UpdateGame(float dt) {
             });
     }
 
-    profiler.startSection("Update World");
+    profiler.startSection("World");
 
     if(spGameController) spGameController->Update(dt);
 
     UpdateKeys();
     world->UpdateWorld(dt);
-    profiler.startSection("Check Collisions");
+    profiler.startSection("Collisions");
     // Check for collisions
     CheckCollisions();
 
-    profiler.startSection("Update Audio");
+    profiler.startSection("Audio");
     audioEngine.Update(&world->GetMainCamera());
 
     clearGraveyard();
-    profiler.startSection("Prepare Render");
+    profiler.startSection("RenderPrep");
     bulletWorld->debugDrawWorld();
 
-    profiler.startSection("Render Decals");
+    profiler.startSection("Decals");
     // Fade decal after sometime - @Kieran: Didn't forget to call the Update function this time :)
     renderer->GetDecalSystem().Update(dt);
 
@@ -158,7 +158,6 @@ void TutorialGame::UpdatePlayer(float dt, bool camOnly) {
         if (player->GetOwner()) respawn = instance->GetRandomRespawn(player->GetOwner()->GetUserID() - 1);
         else respawn = instance->GetRandomRespawn(1);
 
-        std::cout << "Here" << std::endl;
         btTransform& transform = player->GetPhysicsObject()->GetRigidBody()->getWorldTransform();
 
         transform.setOrigin(respawn->position);

--- a/TeamProject/TutorialGame.h
+++ b/TeamProject/TutorialGame.h
@@ -162,6 +162,8 @@ namespace NCL {
 
             void SetFreeCam(bool b) { freeCam = b; }
 
+            bool ShowingProfiler() { return showProfiling; }
+
         protected:
             void InitialiseAssets();
 

--- a/TeamProject/main.cpp
+++ b/TeamProject/main.cpp
@@ -109,6 +109,11 @@ int main(int argc, char** argv) {
     window->GetTimer().GetTimeDeltaSeconds();
 
     bool quit = false;
+    int fps = 0;
+    int frames = 0;
+    float elapsed = 0;
+    float last = 0;
+
     while (window->UpdateWindow() && !window->GetKeyboard()->KeyPressed(KeyCodes::ESCAPE) && !quit) {
         if (window->GetKeyboard()->KeyPressed(KeyCodes::NUM1)) {
             locked = !locked;
@@ -116,6 +121,16 @@ int main(int argc, char** argv) {
             window->LockMouseToWindow(locked);
         }
         float dt = window->GetTimer().GetTimeDeltaSeconds();
+        elapsed += dt;
+        
+        if (elapsed - last >= 0.5) {
+            fps = frames * 2;
+            frames = 0;
+            last += 0.5;
+        }
+
+        Debug::Print("FPS: " + std::to_string(fps), { 1.875, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
+
         controller->Update(dt);
         window->SetTitle("Gametech frame time:" + std::to_string(1000.0f * dt));
 
@@ -165,5 +180,6 @@ int main(int argc, char** argv) {
         renderer->collectFrameObjects(game->GetWorld());
         renderer->drawFrame(dt);
         Debug::UpdateRenderables(dt);
+        frames++;
     }
 }

--- a/TeamProject/main.cpp
+++ b/TeamProject/main.cpp
@@ -90,23 +90,21 @@ bool locked = true;
 #ifdef _WIN32
 #include <windows.h>
 #include <psapi.h>
+#endif
 
-size_t WindowsAllocatedMemory() {
+// Get total memory usage in bytes
+// Returns 0 if unknown
+size_t GetAllocatedMemory() {
+#ifdef _WIN32
     PROCESS_MEMORY_COUNTERS info;
     if (GetProcessMemoryInfo(GetCurrentProcess(), &info, sizeof(info))) {
         return info.WorkingSetSize; 
     }
     return 0;
-}
 #endif
+}
 
 int main(int argc, char** argv) {
-    std::function<size_t(void)> GetAllocatedMemory;
-
-#ifdef _WIN32
-    GetAllocatedMemory = &WindowsAllocatedMemory;
-#endif
-
     auto config = Config("user-config.jsonc", Assets::DEFAULTCONFIG);
     bool quickStart = config.get<bool>("quickStart");
 
@@ -131,7 +129,7 @@ int main(int argc, char** argv) {
     
     int fps = 0;
     int frames = 0;
-    int megabytes = 0;
+    size_t megabytes = 0;
 
     float elapsed = 0;
     float last = 0;
@@ -151,18 +149,15 @@ int main(int argc, char** argv) {
             fps = frames * 2;
             frames = 0;
 
-            // Memory Usage.
-            if (GetAllocatedMemory != nullptr) {
-                size_t allocatedMemory = GetAllocatedMemory();
-                megabytes = (int)allocatedMemory / (1024 * 1024);
-            }
+            megabytes = GetAllocatedMemory() / (1024 * 1024);
 
             last += 0.5;
         }
 
         if (game->ShowingProfiler()) {
             Debug::Print("FPS: " + std::to_string(fps), { 1.875, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
-            Debug::Print("RAM: " + std::to_string(megabytes) + "MB", { 1.675, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
+            std::string ramUse = megabytes > 0 ? std::to_string(megabytes) : "unknown ";
+            Debug::Print("RAM: " + ramUse + "MB", { 1.675, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
         }
 
         controller->Update(dt);

--- a/TeamProject/main.cpp
+++ b/TeamProject/main.cpp
@@ -159,8 +159,11 @@ int main(int argc, char** argv) {
 
             last += 0.5;
         }
-        Debug::Print("FPS: " + std::to_string(fps), { 1.875, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
-        Debug::Print("RAM: " + std::to_string(megabytes) + "MB", {1.675, 0.05}, {1, 1, 1, 1}, 0.5f);
+
+        if (game->ShowingProfiler()) {
+            Debug::Print("FPS: " + std::to_string(fps), { 1.875, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
+            Debug::Print("RAM: " + std::to_string(megabytes) + "MB", { 1.675, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
+        }
 
         controller->Update(dt);
         window->SetTitle("Gametech frame time:" + std::to_string(1000.0f * dt));
@@ -210,6 +213,7 @@ int main(int argc, char** argv) {
         game->GetResourceManager()->update(dt);
         renderer->collectFrameObjects(game->GetWorld());
         renderer->drawFrame(dt);
+
         Debug::UpdateRenderables(dt);
         frames++;
     }

--- a/TeamProject/main.cpp
+++ b/TeamProject/main.cpp
@@ -87,7 +87,26 @@ Controller* createController(Window* window) {
 }
 bool locked = true;
 
+#ifdef _WIN32
+#include <windows.h>
+#include <psapi.h>
+
+size_t WindowsAllocatedMemory() {
+    PROCESS_MEMORY_COUNTERS info;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &info, sizeof(info))) {
+        return info.WorkingSetSize; 
+    }
+    return 0;
+}
+#endif
+
 int main(int argc, char** argv) {
+    std::function<size_t(void)> GetAllocatedMemory;
+
+#ifdef _WIN32
+    GetAllocatedMemory = &WindowsAllocatedMemory;
+#endif
+
     auto config = Config("user-config.jsonc", Assets::DEFAULTCONFIG);
     bool quickStart = config.get<bool>("quickStart");
 
@@ -109,8 +128,11 @@ int main(int argc, char** argv) {
     window->GetTimer().GetTimeDeltaSeconds();
 
     bool quit = false;
+    
     int fps = 0;
     int frames = 0;
+    int megabytes = 0;
+
     float elapsed = 0;
     float last = 0;
 
@@ -123,13 +145,22 @@ int main(int argc, char** argv) {
         float dt = window->GetTimer().GetTimeDeltaSeconds();
         elapsed += dt;
         
+        // Update Display Statistics.
         if (elapsed - last >= 0.5) {
+            // Framerate
             fps = frames * 2;
             frames = 0;
+
+            // Memory Usage.
+            if (GetAllocatedMemory != nullptr) {
+                size_t allocatedMemory = GetAllocatedMemory();
+                megabytes = (int)allocatedMemory / (1024 * 1024);
+            }
+
             last += 0.5;
         }
-
         Debug::Print("FPS: " + std::to_string(fps), { 1.875, 0.05 }, { 1, 1, 1, 1 }, 0.5f);
+        Debug::Print("RAM: " + std::to_string(megabytes) + "MB", {1.675, 0.05}, {1, 1, 1, 1}, 0.5f);
 
         controller->Update(dt);
         window->SetTitle("Gametech frame time:" + std::to_string(1000.0f * dt));


### PR DESCRIPTION
Only added memory allocation reading for windows as this is the only OS i can test. Includes header guards to prevent errors on PS5 and Linux